### PR TITLE
Use node 24 for npm publish OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # Node.js 24 includes npm 11.5.1+ which is required for Trusted Publishing (OIDC)
+          node-version: 24
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
Node.js 24 includes npm 11.5.1+ which is required for Trusted Publishing (OIDC)

Hopefully fixes this error:

```
an error occurred while publishing @loancrate/json-selector: ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org/ 
You need to authorize this machine using `npm adduser`
```

https://linear.app/loancrate/issue/LC-16108/changesets-config-and-next-release-for-json-selector
