### PR TITLE
LC-16557: Parser support for JMESPath functions, multi-select, and projections

### DIFF
--- a/benchmark/cases.ts
+++ b/benchmark/cases.ts
@@ -64,6 +64,12 @@ const isolatedCases: BenchmarkCase[] = [
   { name: "collection: filter", expression: "foo[?bar == `1`]" },
   { name: "collection: slice start:stop", expression: "foo[1:3]" },
   { name: "collection: slice step", expression: "foo[::2]" },
+  { name: "collection: object project", expression: "foo.*" },
+
+  // Functions
+  { name: "function: single arg", expression: "length(foo)" },
+  { name: "function: multiple args", expression: "starts_with(foo, 'bar')" },
+  { name: "function: expression ref arg", expression: "sort_by(foo, &bar)" },
 
   // Logical
   { name: "logical: not", expression: "!foo" },
@@ -81,6 +87,9 @@ const isolatedCases: BenchmarkCase[] = [
   { name: "syntax: escaped quote", expression: '"foo\\"bar"' },
   { name: "syntax: raw escape", expression: "'it\\'s'" },
   { name: "syntax: unicode escape", expression: '"\\u0041"' },
+  { name: "syntax: expression ref", expression: "&foo.bar" },
+  { name: "syntax: multi-select list", expression: "[foo, bar, baz]" },
+  { name: "syntax: multi-select hash", expression: "{a: foo, b: bar, c: baz}" },
 
   // Composition
   { name: "composition: pipe", expression: "foo | bar" },
@@ -160,6 +169,17 @@ const realWorldCases: BenchmarkCase[] = [
     name: "real: flatten filter flatten pipe",
     expression: "data[].items[?type == 'primary'][].value | [0]",
   },
+
+  // Multi-select and functions
+  {
+    name: "real: multi-select hash",
+    expression: "people[*].{name: name, age: age}",
+  },
+  {
+    name: "real: function in pipe",
+    expression: "people[?age > `20`] | sort_by(@, &age)",
+  },
+  { name: "real: object projection", expression: "config.settings.*.value" },
 ];
 
 // 4. Stress Test Benchmarks
@@ -202,6 +222,11 @@ const stressCases: BenchmarkCase[] = [
     name: "stress: pipe + project + filter",
     expression:
       "users | [*].orders[?total > `100`] | [].items[?inStock == `true`]",
+  },
+  {
+    name: "stress: functions + multi-select",
+    expression:
+      "data[*].{name: name, total: items[*].price} | sort_by(@, &total) | [0]",
   },
 ];
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,55 +1,77 @@
 import { JsonValue } from "type-fest";
 
+/** Discriminator string for each AST node variant, used for exhaustive pattern matching. */
 export type JsonSelectorNodeType = JsonSelector["type"];
 
+/** The current context value (`@`), implicit when no explicit token is written. */
 export interface JsonSelectorCurrent {
   type: "current";
+  /** When true, the `@` token was explicitly written (not an implicit placeholder). */
+  explicit?: boolean;
 }
 
+/** Reference to the root document (`$`), enabling access to top-level data from nested contexts. */
 export interface JsonSelectorRoot {
   type: "root";
 }
 
+/** A constant JSON value embedded directly in the expression (e.g. `'hello'`, `` `42` ``, `true`). */
 export interface JsonSelectorLiteral {
   type: "literal";
   value: JsonValue;
+  /** When true, this literal was written with backtick syntax (e.g., `` `true` `` instead of bare `true`). */
+  backtickSyntax?: boolean;
 }
 
+/** A bare field name applied to the current context, e.g. `foo`. */
 export interface JsonSelectorIdentifier {
   type: "identifier";
   id: string;
 }
 
+/** Dot-notation property access on a sub-expression, e.g. `expr.field`. */
 export interface JsonSelectorFieldAccess {
   type: "fieldAccess";
   expression: JsonSelector;
   field: string;
 }
 
+/** Numeric array index access on a sub-expression, e.g. `expr[0]` or `expr[-1]`. */
 export interface JsonSelectorIndexAccess {
   type: "indexAccess";
   expression: JsonSelector;
   index: number;
 }
 
+/** LoanCrate extension: selects an array element by its `id` property, e.g. `expr['my-id']`. */
 export interface JsonSelectorIdAccess {
   type: "idAccess";
   expression: JsonSelector;
   id: string;
 }
 
+/** Array wildcard projection (`[*]`), applying an optional sub-expression to each element. */
 export interface JsonSelectorProject {
   type: "project";
   expression: JsonSelector;
   projection?: JsonSelector;
 }
 
+/** Wildcard projection over object values (`.*`), optionally applying a sub-expression to each value. */
+export interface JsonSelectorObjectProject {
+  type: "objectProject";
+  expression: JsonSelector;
+  projection?: JsonSelector;
+}
+
+/** Array filter that retains only elements where the condition is truthy, e.g. `expr[?age > 18]`. */
 export interface JsonSelectorFilter {
   type: "filter";
   expression: JsonSelector;
   condition: JsonSelector;
 }
 
+/** Python-style array slice with optional start, end, and step, e.g. `expr[0:5:2]`. */
 export interface JsonSelectorSlice {
   type: "slice";
   expression: JsonSelector;
@@ -58,18 +80,22 @@ export interface JsonSelectorSlice {
   step?: number;
 }
 
+/** Flattens one level of nested arrays, e.g. `expr[]`. */
 export interface JsonSelectorFlatten {
   type: "flatten";
   expression: JsonSelector;
 }
 
+/** Logical negation: converts a truthy value to `false` and a falsy/empty value to `true`. */
 export interface JsonSelectorNot {
   type: "not";
   expression: JsonSelector;
 }
 
+/** The set of relational and equality operators supported in comparisons. */
 export type JsonSelectorCompareOperator = "<" | "<=" | "==" | ">=" | ">" | "!=";
 
+/** Binary comparison using a relational or equality operator, e.g. `a == b` or `age >= 18`. */
 export interface JsonSelectorCompare {
   type: "compare";
   operator: JsonSelectorCompareOperator;
@@ -77,24 +103,55 @@ export interface JsonSelectorCompare {
   rhs: JsonSelector;
 }
 
+/** Short-circuit logical AND: returns the left operand if falsy, otherwise the right operand. */
 export interface JsonSelectorAnd {
   type: "and";
   lhs: JsonSelector;
   rhs: JsonSelector;
 }
 
+/** Short-circuit logical OR: returns the left operand if truthy, otherwise the right operand. */
 export interface JsonSelectorOr {
   type: "or";
   lhs: JsonSelector;
   rhs: JsonSelector;
 }
 
+/** Pipe operator (`|`) that evaluates the right side against the result of the left side, resetting projections. */
 export interface JsonSelectorPipe {
   type: "pipe";
   lhs: JsonSelector;
   rhs: JsonSelector;
+  /** When true, this pipe originated from dot syntax (e.g., `foo.func()`, `foo.{...}`, `foo.[...]`). */
+  dotSyntax?: boolean;
 }
 
+/** Named function invocation with zero or more argument expressions, e.g. `length(foo)`. */
+export interface JsonSelectorFunctionCall {
+  type: "functionCall";
+  name: string;
+  args: JsonSelector[];
+}
+
+/** Unevaluated expression reference (`&expr`) passed to higher-order functions like `sort_by` and `map`. */
+export interface JsonSelectorExpressionRef {
+  type: "expressionRef";
+  expression: JsonSelector;
+}
+
+/** Evaluates multiple expressions in parallel and collects the results into an array, e.g. `[foo, bar]`. */
+export interface JsonSelectorMultiSelectList {
+  type: "multiSelectList";
+  expressions: JsonSelector[];
+}
+
+/** Evaluates named expressions and collects the results into a new object, e.g. `{a: foo, b: bar}`. */
+export interface JsonSelectorMultiSelectHash {
+  type: "multiSelectHash";
+  entries: Array<{ key: string; value: JsonSelector }>;
+}
+
+/** Discriminated union of all AST node types produced by the selector parser. */
 export type JsonSelector =
   | JsonSelectorCurrent
   | JsonSelectorRoot
@@ -104,6 +161,7 @@ export type JsonSelector =
   | JsonSelectorIndexAccess
   | JsonSelectorIdAccess
   | JsonSelectorProject
+  | JsonSelectorObjectProject
   | JsonSelectorFilter
   | JsonSelectorSlice
   | JsonSelectorFlatten
@@ -111,4 +169,8 @@ export type JsonSelector =
   | JsonSelectorCompare
   | JsonSelectorAnd
   | JsonSelectorOr
-  | JsonSelectorPipe;
+  | JsonSelectorPipe
+  | JsonSelectorFunctionCall
+  | JsonSelectorExpressionRef
+  | JsonSelectorMultiSelectList
+  | JsonSelectorMultiSelectHash;

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -290,18 +290,17 @@ export class Lexer {
   }
 
   /**
-   * Scan &&
+   * Scan & or &&
    */
   private scanAmpersand(start: number): SymbolToken {
     const ch = this.advanceCharCode(); // consume &
     if (ch === 38) {
-      // &
+      // &&
       this.pos++;
       return { type: TokenType.AND, text: "&&", offset: start };
     }
-    throw new Error(
-      `Unexpected character at position ${start}: expected '&&' but got '&'`,
-    );
+    // Single & for expression references
+    return { type: TokenType.AMPERSAND, text: "&", offset: start };
   }
 
   /**

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,6 +1,7 @@
 import { JsonSelector } from "./ast";
 import { Parser } from "./parser";
 
+/** Parses a selector expression string into an AST that can be evaluated, formatted, or compiled into an accessor. */
 export function parseJsonSelector(selectorExpression: string): JsonSelector {
   const parser = new Parser(selectorExpression);
   return parser.parse();

--- a/src/token.ts
+++ b/src/token.ts
@@ -8,8 +8,8 @@ export const enum TokenType {
   RPAREN,
   LBRACKET,
   RBRACKET,
-  LBRACE, // Reserved for future use (multi-select hashes)
-  RBRACE, // Reserved for future use (multi-select hashes)
+  LBRACE,
+  RBRACE,
   DOT,
   COMMA,
   COLON,
@@ -31,6 +31,7 @@ export const enum TokenType {
   DOLLAR,
   STAR,
   QUESTION, // Reserved for future use (ternary operator)
+  AMPERSAND,
   FILTER_BRACKET,
   FLATTEN_BRACKET,
 
@@ -156,6 +157,7 @@ const TOKEN_DESCRIPTIONS: Record<TokenType, string> = {
   [TokenType.DOLLAR]: "'$'",
   [TokenType.STAR]: "'*'",
   [TokenType.QUESTION]: "'?'",
+  [TokenType.AMPERSAND]: "'&'",
   [TokenType.FILTER_BRACKET]: "'[?'",
   [TokenType.FLATTEN_BRACKET]: "'[]'",
   [TokenType.IDENTIFIER]: "identifier",

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,8 +8,16 @@ export function asArray(value: unknown): unknown[] {
   return value == null ? [] : isArray(value) ? value : [value];
 }
 
+/** Tuple type that guarantees at least one element is present. */
+export type NonEmptyArray<T> = [T, ...T[]];
+
+/** Type guard that narrows an array to {@link NonEmptyArray}, confirming it has at least one element. */
+export function isNonEmptyArray<T>(arr: T[]): arr is NonEmptyArray<T> {
+  return arr.length > 0;
+}
+
 export function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value != null;
+  return typeof value === "object" && value != null && !isArray(value);
 }
 
 export function isFalseOrEmpty(value: unknown): boolean {

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -3,14 +3,19 @@ import {
   JsonSelectorAnd,
   JsonSelectorCompare,
   JsonSelectorCurrent,
+  JsonSelectorExpressionRef,
   JsonSelectorFieldAccess,
   JsonSelectorFilter,
   JsonSelectorFlatten,
+  JsonSelectorFunctionCall,
   JsonSelectorIdAccess,
   JsonSelectorIdentifier,
   JsonSelectorIndexAccess,
   JsonSelectorLiteral,
+  JsonSelectorMultiSelectHash,
+  JsonSelectorMultiSelectList,
   JsonSelectorNot,
+  JsonSelectorObjectProject,
   JsonSelectorOr,
   JsonSelectorPipe,
   JsonSelectorProject,
@@ -35,6 +40,11 @@ export interface Visitor<R, C> {
   and(node: JsonSelectorAnd, context: C): R;
   or(node: JsonSelectorOr, context: C): R;
   pipe(node: JsonSelectorPipe, context: C): R;
+  functionCall?(node: JsonSelectorFunctionCall, context: C): R;
+  expressionRef?(node: JsonSelectorExpressionRef, context: C): R;
+  multiSelectList?(node: JsonSelectorMultiSelectList, context: C): R;
+  multiSelectHash?(node: JsonSelectorMultiSelectHash, context: C): R;
+  objectProject?(node: JsonSelectorObjectProject, context: C): R;
 }
 
 export function visitJsonSelector<R, C>(
@@ -75,5 +85,30 @@ export function visitJsonSelector<R, C>(
       return visitor.or(selector, context);
     case "pipe":
       return visitor.pipe(selector, context);
+    case "functionCall":
+      if (!visitor.functionCall) {
+        throw new Error(`Unsupported node type: ${selector.type}`);
+      }
+      return visitor.functionCall(selector, context);
+    case "expressionRef":
+      if (!visitor.expressionRef) {
+        throw new Error(`Unsupported node type: ${selector.type}`);
+      }
+      return visitor.expressionRef(selector, context);
+    case "multiSelectList":
+      if (!visitor.multiSelectList) {
+        throw new Error(`Unsupported node type: ${selector.type}`);
+      }
+      return visitor.multiSelectList(selector, context);
+    case "multiSelectHash":
+      if (!visitor.multiSelectHash) {
+        throw new Error(`Unsupported node type: ${selector.type}`);
+      }
+      return visitor.multiSelectHash(selector, context);
+    case "objectProject":
+      if (!visitor.objectProject) {
+        throw new Error(`Unsupported node type: ${selector.type}`);
+      }
+      return visitor.objectProject(selector, context);
   }
 }

--- a/test/access.test.ts
+++ b/test/access.test.ts
@@ -455,8 +455,7 @@ describe("makeJsonSelectorAccessor", () => {
       expect(acc.isValidContext(null)).toBe(false);
       expect(acc.isValidContext("string")).toBe(false);
       expect(acc.isValidContext(42)).toBe(false);
-      // Note: arrays are objects in JS, so isObject returns true for them
-      expect(acc.isValidContext([])).toBe(true);
+      expect(acc.isValidContext([])).toBe(false);
     });
   });
 

--- a/test/lexer.test.ts
+++ b/test/lexer.test.ts
@@ -1,4 +1,4 @@
-import assert from "assert";
+import assert from "node:assert/strict";
 import { Lexer } from "../src/lexer";
 import { describeTokenType, Token, TokenType } from "../src/token";
 
@@ -559,10 +559,12 @@ describe("Lexer", () => {
       );
     });
 
-    test("throws on single ampersand", () => {
-      expect(() => tokenize("&")).toThrow(
-        "Unexpected character at position 0: expected '&&' but got '&'",
-      );
+    test("parses single ampersand as AMPERSAND token", () => {
+      // Single ampersand is now valid for expression references (&expr)
+      const result = tokenize("&");
+      expect(result.type).toBe(TokenType.AMPERSAND);
+      expect(result.text).toBe("&");
+      expect(result.offset).toBe(0);
     });
 
     test("reports correct position for error", () => {


### PR DESCRIPTION
## Summary
- Function call parsing: `name(args)` with dot syntax `foo.func(args)`
- Multi-select lists: `[expr1, expr2, ...]` and dot syntax `foo.[...]`
- Multi-select hashes: `{key: expr, ...}` and dot syntax `foo.{...}`
- Object projections: `.*` with projection continuation
- Expression references: `&expr` for higher-order functions
- Keyword literals: `true`, `false`, `null` without backtick syntax

PR 2 of 4 for [LC-16156](https://linear.app/loancrate/issue/LC-16156). Depends on PR 1 (AST/lexer).

## Test plan
- [x] All existing tests pass (972 passed, 97 skipped)
- [x] Build succeeds
- [x] New parser tests for all added syntax
- [x] New benchmark cases for added syntax