### PR TITLE
LC-16565: Add JEP-15 string slice support

### DIFF
--- a/src/access.ts
+++ b/src/access.ts
@@ -387,7 +387,7 @@ function makeAccessorInternal(
           }
           isValidContext(context: unknown, rootContext = context) {
             const value = base.get(context, rootContext);
-            return isArray(value);
+            return isArray(value) || typeof value === "string";
           }
           get(context: unknown, rootContext = context) {
             const arr = base.get(context, rootContext);

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -260,7 +260,7 @@ export function filter(
   return result;
 }
 
-/** Extracts a sub-array using Python-style slice semantics with optional start, end, and step. */
+/** Extracts a sub-sequence from an array or string using Python-style slice semantics. */
 export function slice(
   value: unknown[],
   start: number | undefined,
@@ -268,22 +268,40 @@ export function slice(
   step?: number,
 ): unknown[];
 export function slice(
-  value: unknown,
+  value: string,
   start: number | undefined,
   end?: number,
   step?: number,
-): unknown[] | null;
+): string;
 export function slice(
   value: unknown,
   start: number | undefined,
   end?: number,
   step?: number,
-): unknown[] | null {
-  if (!isArray(value)) {
-    return null;
+): unknown[] | string | null;
+export function slice(
+  value: unknown,
+  start: number | undefined,
+  end?: number,
+  step?: number,
+): unknown[] | string | null {
+  if (isArray(value)) {
+    return collectSlice(value, start, end, step);
   }
+  if (typeof value === "string") {
+    return collectSlice(Array.from(value), start, end, step).join("");
+  }
+  return null;
+}
+
+function collectSlice<T>(
+  value: readonly T[],
+  start: number | undefined,
+  end?: number,
+  step?: number,
+): T[] {
   ({ start, end, step } = normalizeSlice(value.length, start, end, step));
-  const collected: unknown[] = [];
+  const collected: T[] = [];
   if (step > 0) {
     for (let i = start; i < end; i += step) {
       collected.push(value[i]);

--- a/test/access.test.ts
+++ b/test/access.test.ts
@@ -1021,9 +1021,31 @@ describe("makeJsonSelectorAccessor", () => {
       expect(acc.get({ a: [1, 2, 3, 4, 5] })).toStrictEqual([5, 4, 3, 2, 1]);
     });
 
-    test("get on non-array returns null", () => {
+    test("get with string", () => {
       const acc = accessor("a[1:3]");
-      expect(acc.get({ a: "string" })).toBeNull();
+      expect(acc.get({ a: "foobar" })).toBe("oo");
+    });
+
+    test("get with string step", () => {
+      const acc = accessor("a[::2]");
+      expect(acc.get({ a: "abcdef" })).toBe("ace");
+    });
+
+    test("get with string negative step", () => {
+      const acc = accessor("a[::-1]");
+      expect(acc.get({ a: "foobar" })).toBe("raboof");
+    });
+
+    test("get with unicode string uses code points", () => {
+      const acc = accessor("a[1:3]");
+      expect(acc.get({ a: "\ud83d\ude00\ud83d\ude03\ud83d\ude04\ud83d\ude01" })).toBe(
+        "\ud83d\ude03\ud83d\ude04",
+      );
+    });
+
+    test("get on non-array/non-string returns null", () => {
+      const acc = accessor("a[1:3]");
+      expect(acc.get({ a: { value: "string" } })).toBeNull();
     });
 
     test("set with positive step", () => {
@@ -1075,11 +1097,11 @@ describe("makeJsonSelectorAccessor", () => {
       expect(obj.a).toBe("string");
     });
 
-    test("isValidContext for arrays", () => {
+    test("isValidContext for arrays and strings", () => {
       const acc = accessor("a[1:3]");
       expect(acc.isValidContext({ a: [] })).toBe(true);
       expect(acc.isValidContext({ a: [1, 2, 3] })).toBe(true);
-      expect(acc.isValidContext({ a: "string" })).toBe(false);
+      expect(acc.isValidContext({ a: "string" })).toBe(true);
       expect(acc.isValidContext({ a: null })).toBe(false);
     });
   });

--- a/test/access.test.ts
+++ b/test/access.test.ts
@@ -1038,9 +1038,9 @@ describe("makeJsonSelectorAccessor", () => {
 
     test("get with unicode string uses code points", () => {
       const acc = accessor("a[1:3]");
-      expect(acc.get({ a: "\ud83d\ude00\ud83d\ude03\ud83d\ude04\ud83d\ude01" })).toBe(
-        "\ud83d\ude03\ud83d\ude04",
-      );
+      expect(
+        acc.get({ a: "\ud83d\ude00\ud83d\ude03\ud83d\ude04\ud83d\ude01" }),
+      ).toBe("\ud83d\ude03\ud83d\ude04");
     });
 
     test("get on non-array/non-string returns null", () => {

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -140,12 +140,24 @@ describe("evaluate", () => {
       context: { s: string };
       result: string;
     }> = [
-      { expression: "s[:]", context: { s: "0123456789" }, result: "0123456789" },
-      { expression: "s[0:20]", context: { s: "0123456789" }, result: "0123456789" },
+      {
+        expression: "s[:]",
+        context: { s: "0123456789" },
+        result: "0123456789",
+      },
+      {
+        expression: "s[0:20]",
+        context: { s: "0123456789" },
+        result: "0123456789",
+      },
       { expression: "s[10:-20]", context: { s: "0123456789" }, result: "" },
       { expression: "s[-4:-1]", context: { s: "0123456789" }, result: "678" },
       { expression: "s[:-5:-1]", context: { s: "0123456789" }, result: "9876" },
-      { expression: "s[10:0:-1]", context: { s: "0123456789" }, result: "987654321" },
+      {
+        expression: "s[10:0:-1]",
+        context: { s: "0123456789" },
+        result: "987654321",
+      },
       { expression: "s[8:2:-2]", context: { s: "0123456789" }, result: "864" },
       { expression: "s[3:3]", context: { s: "0123456789" }, result: "" },
       { expression: "s[::-1]", context: { s: "" }, result: "" },

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -100,6 +100,44 @@ describe("evaluate", () => {
       "bob",
     ]);
   });
+
+  test("slice supports strings", () => {
+    const selector = parseJsonSelector("s[1:3]");
+    expect(evaluateJsonSelector(selector, { s: "foobar" })).toBe("oo");
+  });
+
+  test("slice supports reverse strings", () => {
+    const selector = parseJsonSelector("s[::-1]");
+    expect(evaluateJsonSelector(selector, { s: "foobar" })).toBe("raboof");
+  });
+
+  test("slice supports string step", () => {
+    const selector = parseJsonSelector("s[::2]");
+    expect(evaluateJsonSelector(selector, { s: "abcdef" })).toBe("ace");
+  });
+
+  test("slice on string uses Unicode code points", () => {
+    const selector = parseJsonSelector("s[1:3]");
+    expect(
+      evaluateJsonSelector(selector, {
+        s: "\ud83d\ude00\ud83d\ude03\ud83d\ude04\ud83d\ude01",
+      }),
+    ).toBe("\ud83d\ude03\ud83d\ude04");
+  });
+
+  test("slice reverses Unicode strings by code point", () => {
+    const selector = parseJsonSelector("s[::-1]");
+    expect(
+      evaluateJsonSelector(selector, {
+        s: "\ud83d\ude00\ud83d\ude03\ud83d\ude04\ud83d\ude01",
+      }),
+    ).toBe("\ud83d\ude01\ud83d\ude04\ud83d\ude03\ud83d\ude00");
+  });
+
+  test("slice returns null for non-array/non-string values", () => {
+    const selector = parseJsonSelector("s[1:3]");
+    expect(evaluateJsonSelector(selector, { s: 123 })).toBeNull();
+  });
 });
 
 describe("project", () => {

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -134,6 +134,36 @@ describe("evaluate", () => {
     ).toBe("\ud83d\ude01\ud83d\ude04\ud83d\ude03\ud83d\ude00");
   });
 
+  test("slice supports string boundary and negative-index cases", () => {
+    const cases: Array<{
+      expression: string;
+      context: { s: string };
+      result: string;
+    }> = [
+      { expression: "s[:]", context: { s: "0123456789" }, result: "0123456789" },
+      { expression: "s[0:20]", context: { s: "0123456789" }, result: "0123456789" },
+      { expression: "s[10:-20]", context: { s: "0123456789" }, result: "" },
+      { expression: "s[-4:-1]", context: { s: "0123456789" }, result: "678" },
+      { expression: "s[:-5:-1]", context: { s: "0123456789" }, result: "9876" },
+      { expression: "s[10:0:-1]", context: { s: "0123456789" }, result: "987654321" },
+      { expression: "s[8:2:-2]", context: { s: "0123456789" }, result: "864" },
+      { expression: "s[3:3]", context: { s: "0123456789" }, result: "" },
+      { expression: "s[::-1]", context: { s: "" }, result: "" },
+    ];
+
+    for (const { expression, context, result } of cases) {
+      const selector = parseJsonSelector(expression);
+      expect(evaluateJsonSelector(selector, context)).toBe(result);
+    }
+  });
+
+  test("slice throws for zero step on strings", () => {
+    const selector = parseJsonSelector("s[8:2:0]");
+    expect(() => evaluateJsonSelector(selector, { s: "0123456789" })).toThrow(
+      "step cannot be 0",
+    );
+  });
+
   test("slice returns null for non-array/non-string values", () => {
     const selector = parseJsonSelector("s[1:3]");
     expect(evaluateJsonSelector(selector, { s: 123 })).toBeNull();

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -134,40 +134,41 @@ describe("evaluate", () => {
     ).toBe("\ud83d\ude01\ud83d\ude04\ud83d\ude03\ud83d\ude00");
   });
 
-  test("slice supports string boundary and negative-index cases", () => {
-    const cases: Array<{
-      expression: string;
-      context: { s: string };
-      result: string;
-    }> = [
-      {
-        expression: "s[:]",
-        context: { s: "0123456789" },
-        result: "0123456789",
-      },
-      {
-        expression: "s[0:20]",
-        context: { s: "0123456789" },
-        result: "0123456789",
-      },
-      { expression: "s[10:-20]", context: { s: "0123456789" }, result: "" },
-      { expression: "s[-4:-1]", context: { s: "0123456789" }, result: "678" },
-      { expression: "s[:-5:-1]", context: { s: "0123456789" }, result: "9876" },
-      {
-        expression: "s[10:0:-1]",
-        context: { s: "0123456789" },
-        result: "987654321",
-      },
-      { expression: "s[8:2:-2]", context: { s: "0123456789" }, result: "864" },
-      { expression: "s[3:3]", context: { s: "0123456789" }, result: "" },
-      { expression: "s[::-1]", context: { s: "" }, result: "" },
-    ];
+  const stringSliceBoundaryCases: Array<{
+    expression: string;
+    context: { s: string };
+    result: string;
+  }> = [
+    {
+      expression: "s[:]",
+      context: { s: "0123456789" },
+      result: "0123456789",
+    },
+    {
+      expression: "s[0:20]",
+      context: { s: "0123456789" },
+      result: "0123456789",
+    },
+    { expression: "s[10:-20]", context: { s: "0123456789" }, result: "" },
+    { expression: "s[-4:-1]", context: { s: "0123456789" }, result: "678" },
+    { expression: "s[:-5:-1]", context: { s: "0123456789" }, result: "9876" },
+    {
+      expression: "s[10:0:-1]",
+      context: { s: "0123456789" },
+      result: "987654321",
+    },
+    { expression: "s[8:2:-2]", context: { s: "0123456789" }, result: "864" },
+    { expression: "s[3:3]", context: { s: "0123456789" }, result: "" },
+    { expression: "s[::-1]", context: { s: "" }, result: "" },
+  ];
 
-    for (const { expression, context, result } of cases) {
+  it.each(stringSliceBoundaryCases)(
+    "slice supports string boundary and negative-index case: $expression",
+    ({ expression, context, result }) => {
       const selector = parseJsonSelector(expression);
       expect(evaluateJsonSelector(selector, context)).toBe(result);
-    }
-  });
+    },
+  );
 
   test("slice throws for zero step on strings", () => {
     const selector = parseJsonSelector("s[8:2:0]");


### PR DESCRIPTION
This PR is the first of ~4 to complete the features of JMESPath Community. This is the simplest one.

This implements [JEP-15 string slice](https://github.com/jmespath-community/jmespath.spec/blob/main/jep-015-string-slices.md) support in the evaluator and slice accessor path.
It extends `slice()` to handle strings using code-point-safe slicing via `Array.from`, while preserving existing array semantics and null behavior for unsupported types.
It updates slice accessor context validation for string reads and keeps string set/delete behavior as no-ops.
Tests were added in unit suites (`test/evaluate.test.ts` and `test/access.test.ts`) and the full test suite passes.
