### PR TITLE
Add JEP-21 ternary conditional support

### DIFF
--- a/src/access.ts
+++ b/src/access.ts
@@ -501,6 +501,24 @@ function makeAccessorInternal(
         };
         return new Accessor();
       },
+      ternary(selector) {
+        const { condition, consequent, alternate } = selector;
+        const ca = makeAccessorInternal(condition, options);
+        const ta = makeAccessorInternal(consequent, options);
+        const aa = makeAccessorInternal(alternate, options);
+        const Accessor = class extends ReadOnlyAccessor {
+          constructor() {
+            super(selector);
+          }
+          get(context: unknown, rootContext = context) {
+            const cv = ca.get(context, rootContext);
+            return isFalseOrEmpty(cv)
+              ? aa.get(context, rootContext)
+              : ta.get(context, rootContext);
+          }
+        };
+        return new Accessor();
+      },
       pipe(selector) {
         const { lhs, rhs } = selector;
         const la = makeAccessorInternal(lhs, options);

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -117,6 +117,14 @@ export interface JsonSelectorOr {
   rhs: JsonSelector;
 }
 
+/** Conditional expression (`condition ? consequent : alternate`) using JMESPath truthiness rules. */
+export interface JsonSelectorTernary {
+  type: "ternary";
+  condition: JsonSelector;
+  consequent: JsonSelector;
+  alternate: JsonSelector;
+}
+
 /** Pipe operator (`|`) that evaluates the right side against the result of the left side, resetting projections. */
 export interface JsonSelectorPipe {
   type: "pipe";
@@ -169,6 +177,7 @@ export type JsonSelector =
   | JsonSelectorCompare
   | JsonSelectorAnd
   | JsonSelectorOr
+  | JsonSelectorTernary
   | JsonSelectorPipe
   | JsonSelectorFunctionCall
   | JsonSelectorExpressionRef

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -134,6 +134,12 @@ function evaluate(
         const lv = evaluate(lhs, context, evalCtx);
         return !isFalseOrEmpty(lv) ? lv : evaluate(rhs, context, evalCtx);
       },
+      ternary({ condition, consequent, alternate }) {
+        const cv = evaluate(condition, context, evalCtx);
+        return isFalseOrEmpty(cv)
+          ? evaluate(alternate, context, evalCtx)
+          : evaluate(consequent, context, evalCtx);
+      },
       pipe({ lhs, rhs }) {
         return evaluate(rhs, evaluate(lhs, context, evalCtx), evalCtx);
       },

--- a/src/format.ts
+++ b/src/format.ts
@@ -8,8 +8,9 @@ const PRECEDENCE_NOT = 2;
 const PRECEDENCE_COMPARE = 3;
 const PRECEDENCE_AND = 4;
 const PRECEDENCE_OR = 5;
-const PRECEDENCE_PIPE = 6;
-const PRECEDENCE_MAX = 7;
+const PRECEDENCE_TERNARY = 6;
+const PRECEDENCE_PIPE = 7;
+const PRECEDENCE_MAX = 8;
 
 const operatorPrecedence: { [type in JsonSelectorNodeType]?: number } = {
   fieldAccess: PRECEDENCE_ACCESS,
@@ -27,6 +28,7 @@ const operatorPrecedence: { [type in JsonSelectorNodeType]?: number } = {
   compare: PRECEDENCE_COMPARE,
   and: PRECEDENCE_AND,
   or: PRECEDENCE_OR,
+  ternary: PRECEDENCE_TERNARY,
   pipe: PRECEDENCE_PIPE,
 };
 
@@ -153,6 +155,12 @@ function format(selector: JsonSelector): string {
         const lv = formatSubexpression(lhs, PRECEDENCE_OR);
         const rv = formatSubexpression(rhs, PRECEDENCE_OR - 1);
         return `${lv} || ${rv}`;
+      },
+      ternary({ condition, consequent, alternate }) {
+        const cv = formatSubexpression(condition, PRECEDENCE_TERNARY - 1);
+        const tv = format(consequent);
+        const av = formatSubexpression(alternate, PRECEDENCE_TERNARY);
+        return `${cv} ? ${tv} : ${av}`;
       },
       pipe({ lhs, rhs, dotSyntax }) {
         const lv = formatSubexpression(lhs, PRECEDENCE_PIPE);

--- a/src/token.ts
+++ b/src/token.ts
@@ -30,7 +30,7 @@ export const enum TokenType {
   AT,
   DOLLAR,
   STAR,
-  QUESTION, // Reserved for future use (ternary operator)
+  QUESTION, // Ternary operator
   AMPERSAND,
   FILTER_BRACKET,
   FLATTEN_BRACKET,

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -21,6 +21,7 @@ import {
   JsonSelectorProject,
   JsonSelectorRoot,
   JsonSelectorSlice,
+  JsonSelectorTernary,
 } from "./ast";
 
 export interface Visitor<R, C> {
@@ -39,6 +40,7 @@ export interface Visitor<R, C> {
   compare(node: JsonSelectorCompare, context: C): R;
   and(node: JsonSelectorAnd, context: C): R;
   or(node: JsonSelectorOr, context: C): R;
+  ternary(node: JsonSelectorTernary, context: C): R;
   pipe(node: JsonSelectorPipe, context: C): R;
   functionCall(node: JsonSelectorFunctionCall, context: C): R;
   expressionRef(node: JsonSelectorExpressionRef, context: C): R;
@@ -83,6 +85,8 @@ export function visitJsonSelector<R, C>(
       return visitor.and(selector, context);
     case "or":
       return visitor.or(selector, context);
+    case "ternary":
+      return visitor.ternary(selector, context);
     case "pipe":
       return visitor.pipe(selector, context);
     case "functionCall":

--- a/test/access.test.ts
+++ b/test/access.test.ts
@@ -392,6 +392,50 @@ describe("makeJsonSelectorAccessor", () => {
     });
   });
 
+  describe("ternary (?:)", () => {
+    test("returns consequent when condition is truthy", () => {
+      const acc = accessor("cond ? yes : no");
+      expect(acc.get({ cond: 1, yes: "selected", no: "fallback" })).toBe(
+        "selected",
+      );
+    });
+
+    test("returns alternate when condition is falsy by JMESPath rules", () => {
+      const acc = accessor("cond ? yes : no");
+      expect(acc.get({ cond: [], yes: "selected", no: "fallback" })).toBe(
+        "fallback",
+      );
+    });
+
+    test("set is no-op", () => {
+      const acc = accessor("cond ? yes : no");
+      const obj = { cond: true, yes: "selected", no: "fallback" };
+      acc.set("changed", obj);
+      expect(obj).toStrictEqual({
+        cond: true,
+        yes: "selected",
+        no: "fallback",
+      });
+    });
+
+    test("delete is no-op", () => {
+      const acc = accessor("cond ? yes : no");
+      const obj = { cond: false, yes: "selected", no: "fallback" };
+      acc.delete(obj);
+      expect(obj).toStrictEqual({
+        cond: false,
+        yes: "selected",
+        no: "fallback",
+      });
+    });
+
+    test("isValidContext always returns true", () => {
+      const acc = accessor("cond ? yes : no");
+      expect(acc.isValidContext(null)).toBe(true);
+      expect(acc.isValidContext({})).toBe(true);
+    });
+  });
+
   // ============================================================
   // Mutable accessors
   // ============================================================

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -181,6 +181,46 @@ describe("evaluate", () => {
     const selector = parseJsonSelector("s[1:3]");
     expect(evaluateJsonSelector(selector, { s: 123 })).toBeNull();
   });
+
+  describe("ternary operator", () => {
+    test.each<[string, unknown, unknown]>([
+      ["null is falsy", null, "fallback"],
+      ["false is falsy", false, "fallback"],
+      ["empty string is falsy", "", "fallback"],
+      ["empty array is falsy", [], "fallback"],
+      ["empty object is falsy", {}, "fallback"],
+      ["zero is truthy", 0, "selected"],
+      ["non-empty string is truthy", "x", "selected"],
+      ["non-empty array is truthy", [1], "selected"],
+      ["non-empty object is truthy", { a: 1 }, "selected"],
+    ])("%s", (_name, value, expected) => {
+      const selector = parseJsonSelector("value ? selected : fallback");
+      const context = { value, selected: "selected", fallback: "fallback" };
+      expect(evaluateJsonSelector(selector, context)).toBe(expected);
+    });
+
+    test("nested ternary evaluates right-associative alternate branch", () => {
+      const selector = parseJsonSelector("a ? b : c ? d : e");
+      expect(
+        evaluateJsonSelector(selector, {
+          a: false,
+          b: "b",
+          c: true,
+          d: "d",
+          e: "e",
+        }),
+      ).toBe("d");
+      expect(
+        evaluateJsonSelector(selector, {
+          a: false,
+          b: "b",
+          c: false,
+          d: "d",
+          e: "e",
+        }),
+      ).toBe("e");
+    });
+  });
 });
 
 describe("project", () => {


### PR DESCRIPTION
https://linear.app/loancrate/issue/LC-16652/add-jep-21-ternary-conditional-support-to-json-selector

This PR adds JEP-21 ternary conditional expressions (`a ? b : c`) across parsing, AST, evaluation, formatting, and accessors. It's the second of ~4 PRs for adding all JMESPath Community features.

It includes precedence and associativity behavior per spec, plus a parser note documenting why our handling differs from the current upstream implementation for pipe interaction.
Tests were added in parse/evaluate/format/access suites for AST shape, truthiness semantics, precedence, round-tripping, and read-only accessor behavior. Code coverage remains at 100%.