### PR TITLE
LC-16703: Add arithmetic expression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # LoanCrate JSON Selectors
 
-LoanCrate JSON Selectors implement the full [JMESPath](https://jmespath.org) specification
-with the following extensions:
+LoanCrate JSON Selectors is a production-focused TypeScript implementation for querying and updating JSON documents with JMESPath-style expressions. It provides a hand-written Pratt parser, typed AST/visitor APIs, formatting back to expression strings, and read/write/delete accessors for mutating selected values.
 
-- A shorthand for selecting an object from an array based on ID.
-- A root-node expression, as added in the [JMESPath Community Edition](https://jmespath.site/main/#spec-root-node).
+## Standards and Extensions
 
-The library passes all [JMESPath compliance tests](https://github.com/jmespath/jmespath.test).
+- **Original [JMESPath](https://jmespath.org) spec**: fully implemented.
+- **[JMESPath Community Edition](https://jmespath.site/main/)**: implemented except `let` expressions.
+- **JSON Selector extension**: ID-based index shorthand (`x['id']`).
+- **JSON Selector extension**: bare numeric literals as general expressions (for example `a-1`, `-1`, `foo[?price > 0]`) in addition to backtick numeric literals.
+
+This includes JMESPath Community features such as root-node expressions (`$`) and arithmetic expressions. The library also passes all [JMESPath compliance tests](https://github.com/jmespath/jmespath.test).
 
 To allow for selection by ID, we extend index expressions to accept a
 [raw string literal](https://jmespath.org/specification.html#raw-string-literals)
@@ -14,6 +17,14 @@ To allow for selection by ID, we extend index expressions to accept a
 of the desired object from an array of objects.
 Formally, `x['y']` would be equivalent to `x[?id == 'y'] | [0]` in JMESPath.
 This should be unambiguous relative to the existing grammar and semantics.
+
+To support arithmetic with bare numeric literals while preserving JMESPath-style
+negative index/slice syntax, `-` is always tokenized as an operator and resolved
+in the parser:
+
+- unary sign over numeric literals is folded at parse time (for example `-42`, `--1`)
+- subtraction in expression position remains standard (for example `a-1`)
+- negative index/slice values are parsed explicitly in bracket/slice grammar (for example `foo[-1]`, `foo[:-1]`)
 
 In addition to the extensions above, this library offers the following features compared to [jmespath.js](https://github.com/jmespath/jmespath.js):
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint src test benchmark",
     "lint:ci": "eslint src test benchmark --max-warnings 0 --format junit --output-file test-results/eslint/junit.xml",
-    "prepare": "npm run build",
+    "prepare": "husky && npm run build",
     "prepublishOnly": "npm run test && npm run lint",
     "release": "changeset publish",
     "test": "jest",

--- a/src/access.ts
+++ b/src/access.ts
@@ -7,6 +7,8 @@ import {
   isIdentityProjection,
   normalizeSlice,
   objectProject,
+  performArithmetic,
+  performUnaryArithmetic,
   project,
   slice,
 } from "./evaluate";
@@ -467,6 +469,38 @@ function makeAccessorInternal(
             const lv = la.get(context, rootContext);
             const rv = ra.get(context, rootContext);
             return compare(lv, rv, operator);
+          }
+        };
+        return new Accessor();
+      },
+      arithmetic(selector) {
+        const la = makeAccessorInternal(selector.lhs, options);
+        const ra = makeAccessorInternal(selector.rhs, options);
+        const Accessor = class extends ReadOnlyAccessor {
+          constructor() {
+            super(selector);
+          }
+          get(context: unknown, rootContext = context) {
+            return performArithmetic(
+              la.get(context, rootContext),
+              ra.get(context, rootContext),
+              selector.operator,
+            );
+          }
+        };
+        return new Accessor();
+      },
+      unaryArithmetic(selector) {
+        const base = makeAccessorInternal(selector.expression, options);
+        const Accessor = class extends ReadOnlyAccessor {
+          constructor() {
+            super(selector);
+          }
+          get(context: unknown, rootContext = context) {
+            return performUnaryArithmetic(
+              base.get(context, rootContext),
+              selector.operator,
+            );
           }
         };
         return new Accessor();

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -103,6 +103,33 @@ export interface JsonSelectorCompare {
   rhs: JsonSelector;
 }
 
+/** The set of arithmetic operators supported in binary arithmetic expressions. */
+export type JsonSelectorArithmeticOperator =
+  | "+"
+  | "-"
+  | "*"
+  | "/"
+  | "%"
+  | "//";
+
+/** Binary arithmetic operation, e.g. `a + b`, `price * quantity`, `x // 2`. */
+export interface JsonSelectorArithmetic {
+  type: "arithmetic";
+  operator: JsonSelectorArithmeticOperator;
+  lhs: JsonSelector;
+  rhs: JsonSelector;
+}
+
+/** The set of arithmetic operators supported in unary arithmetic expressions. */
+export type JsonSelectorUnaryArithmeticOperator = "+" | "-";
+
+/** Unary arithmetic operation, e.g. `-a` or `+value`. */
+export interface JsonSelectorUnaryArithmetic {
+  type: "unaryArithmetic";
+  operator: JsonSelectorUnaryArithmeticOperator;
+  expression: JsonSelector;
+}
+
 /** Short-circuit logical AND: returns the left operand if falsy, otherwise the right operand. */
 export interface JsonSelectorAnd {
   type: "and";
@@ -175,6 +202,8 @@ export type JsonSelector =
   | JsonSelectorFlatten
   | JsonSelectorNot
   | JsonSelectorCompare
+  | JsonSelectorArithmetic
+  | JsonSelectorUnaryArithmetic
   | JsonSelectorAnd
   | JsonSelectorOr
   | JsonSelectorTernary

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -104,13 +104,7 @@ export interface JsonSelectorCompare {
 }
 
 /** The set of arithmetic operators supported in binary arithmetic expressions. */
-export type JsonSelectorArithmeticOperator =
-  | "+"
-  | "-"
-  | "*"
-  | "/"
-  | "%"
-  | "//";
+export type JsonSelectorArithmeticOperator = "+" | "-" | "*" | "/" | "%" | "//";
 
 /** Binary arithmetic operation, e.g. `a + b`, `price * quantity`, `x // 2`. */
 export interface JsonSelectorArithmetic {

--- a/src/token.ts
+++ b/src/token.ts
@@ -26,6 +26,14 @@ export const enum TokenType {
   GT,
   GTE,
 
+  // Arithmetic operators
+  PLUS, // "+" (addition, unary plus)
+  MINUS, // "-" (subtraction, unary minus; also Unicode "−")
+  MULTIPLY, // "×" (Unicode U+00D7 multiplication sign only)
+  DIVIDE, // "/" or "÷" (Unicode U+00F7)
+  MODULO, // "%"
+  INT_DIVIDE, // "//"
+
   // Special symbols
   AT,
   DOLLAR,
@@ -153,6 +161,12 @@ const TOKEN_DESCRIPTIONS: Record<TokenType, string> = {
   [TokenType.LTE]: "'<='",
   [TokenType.GT]: "'>'",
   [TokenType.GTE]: "'>='",
+  [TokenType.PLUS]: "'+'",
+  [TokenType.MINUS]: "'-'",
+  [TokenType.MULTIPLY]: "'\u00D7'",
+  [TokenType.DIVIDE]: "'/'",
+  [TokenType.MODULO]: "'%'",
+  [TokenType.INT_DIVIDE]: "'//'",
   [TokenType.AT]: "'@'",
   [TokenType.DOLLAR]: "'$'",
   [TokenType.STAR]: "'*'",

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -1,6 +1,7 @@
 import {
   JsonSelector,
   JsonSelectorAnd,
+  JsonSelectorArithmetic,
   JsonSelectorCompare,
   JsonSelectorCurrent,
   JsonSelectorExpressionRef,
@@ -22,6 +23,7 @@ import {
   JsonSelectorRoot,
   JsonSelectorSlice,
   JsonSelectorTernary,
+  JsonSelectorUnaryArithmetic,
 } from "./ast";
 
 export interface Visitor<R, C> {
@@ -38,6 +40,8 @@ export interface Visitor<R, C> {
   flatten(node: JsonSelectorFlatten, context: C): R;
   not(node: JsonSelectorNot, context: C): R;
   compare(node: JsonSelectorCompare, context: C): R;
+  arithmetic(node: JsonSelectorArithmetic, context: C): R;
+  unaryArithmetic(node: JsonSelectorUnaryArithmetic, context: C): R;
   and(node: JsonSelectorAnd, context: C): R;
   or(node: JsonSelectorOr, context: C): R;
   ternary(node: JsonSelectorTernary, context: C): R;
@@ -81,6 +85,10 @@ export function visitJsonSelector<R, C>(
       return visitor.not(selector, context);
     case "compare":
       return visitor.compare(selector, context);
+    case "arithmetic":
+      return visitor.arithmetic(selector, context);
+    case "unaryArithmetic":
+      return visitor.unaryArithmetic(selector, context);
     case "and":
       return visitor.and(selector, context);
     case "or":

--- a/test/access.test.ts
+++ b/test/access.test.ts
@@ -322,6 +322,40 @@ describe("makeJsonSelectorAccessor", () => {
     });
   });
 
+  describe("arithmetic (+, -, *, /, %, //)", () => {
+    test("get computes arithmetic value", () => {
+      const acc = accessor("a * b + c");
+      expect(acc.get({ a: 2, b: 3, c: 4 })).toBe(10);
+    });
+
+    test("unary arithmetic computes value", () => {
+      expect(accessor("-a").get({ a: 5 })).toBe(-5);
+      expect(accessor("+a").get({ a: 5 })).toBe(5);
+    });
+
+    test("set is no-op", () => {
+      const acc = accessor("a + b");
+      const obj = { a: 1, b: 2 };
+      acc.set(100, obj);
+      expect(obj).toStrictEqual({ a: 1, b: 2 });
+      expect(acc.get(obj)).toBe(3);
+    });
+
+    test("delete is no-op", () => {
+      const acc = accessor("-a");
+      const obj = { a: 2 };
+      acc.delete(obj);
+      expect(obj).toStrictEqual({ a: 2 });
+      expect(acc.get(obj)).toBe(-2);
+    });
+
+    test("isValidContext always returns true", () => {
+      const acc = accessor("a + b");
+      expect(acc.isValidContext(null)).toBe(true);
+      expect(acc.isValidContext({})).toBe(true);
+    });
+  });
+
   describe("and (&&)", () => {
     test("returns lhs if falsy (short-circuit)", () => {
       const acc = accessor("foo && bar");

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -703,13 +703,7 @@ describe("parseJsonSelector", () => {
   });
 
   describe("arithmetic operators", () => {
-    test.each<
-      [
-        string,
-        string,
-        JsonSelector,
-      ]
-    >([
+    test.each<[string, string, JsonSelector]>([
       [
         "addition",
         "a + b",


### PR DESCRIPTION
## Summary

- Add JMESPath Community Edition arithmetic operators (`+`, `-`, `*`, `/`, `%`, `//`) with Unicode aliases (`×`, `÷`, `−`)
- Implement context-free `MINUS` tokenization in the lexer with parser-side disambiguation for subtraction, unary sign, and negative index/slice bounds
- Add constant folding for unary signs over numeric literals at parse time, preserving `backtickSyntax` hints
- Add strict runtime type checking with descriptive error messages (operator, operand role, actual type)
- Add read-only arithmetic accessors following the same pattern as comparison operators
- Refactor parser internals for conciseness and readability, extracting helpers like `parseCompare`, `expressionFrom`, and `parseProjectionContinuation` to reduce duplication and clarify control flow
- Allow bare numeric literals in expression position (e.g. `foo[?price > 0]` or `a - 1`) so users don't need backtick-quoted numbers for common comparisons and arithmetic

Resolves https://linear.app/loancrate/issue/LC-16703/add-arithmetic-expression-support-to-json-selectors

## Test plan
- [x] All existing tests pass (full JMESPath compliance suite)
- [x] New lexer tests for arithmetic token scanning including Unicode operators
- [x] New parser tests for precedence, associativity, constant folding, and error cases
- [x] New evaluation tests for all operators, type errors, and division by zero
- [x] New format tests for roundtrip invariants and precedence-aware parenthesization
- [x] New accessor tests for read-only arithmetic behavior
- [x] 100% code coverage maintained

## Benchmark results (branch vs master, 3 runs each)

### Consistently faster (>10% improvement)

| Case | Run 1 | Run 2 | Run 3 | Avg |
|---|---|---|---|---|
| scale: pipe length 10 | -17.2% | -13.7% | -11.5% | **-14.1%** |
| scale: pipe length 25 | -10.6% | -13.6% | -10.7% | **-11.6%** |
| scale: pipe length 50 | -11.9% | -14.4% | -8.5% | **-11.6%** |
| scale: AND length 10 | -9.8% | -14.3% | -12.1% | **-12.1%** |
| scale: AND length 26 | -12.7% | -14.6% | -11.2% | **-12.8%** |
| scale: OR length 26 | -11.4% | -13.7% | -8.0% | **-11.0%** |

Chained operator scaling tests show consistent improvement, likely from parser refactoring (`parseCompare` helper, `expressionFrom` / `parseProjectionContinuation` restructuring).

### Consistently slower (>10% regression)

| Case | Run 1 | Run 2 | Run 3 | Avg |
|---|---|---|---|---|
| primitive: current | +28.9% | +38.1% | +32.1% | **+33.0%** |

Only consistent regression is on the simplest expression (`@`). Absolute times are 0.03 → 0.05 μs (~15ns difference), likely from the larger binding power table. Negligible in practice.

### No significant regressions on real-world expressions or stress tests.