### PR TITLE
Fix remaining JMESPath Community Edition compliance failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-This is a TypeScript library implementing LoanCrate JSON Selectors. It fully implements original JMESPath, implements JMESPath Community features, and adds two LoanCrate extensions (`['id']` indexing shorthand and bare numeric literals in expression position). The library provides parsing, evaluation, formatting, and read/write/delete accessors for JSON selector expressions.
+This is a TypeScript library implementing LoanCrate JSON Selectors. It fully implements original JMESPath and JMESPath Community Edition, and adds two LoanCrate extensions (`['id']` indexing shorthand and bare numeric literals in expression position). The library provides parsing, evaluation, formatting, and read/write/delete accessors for JSON selector expressions.
 
 ## Development Commands
 
@@ -20,7 +20,7 @@ Cleans `dist/` and builds both UMD and ESM bundles using Rollup.
 
 The parser is implemented as a **hand-written Pratt parser** (precedence-climbing) with a **custom hand-written lexer**.
 
-**Status**: Full JMESPath compliance achieved.
+**Status**: Full JMESPath and JMESPath Community compliance achieved.
 
 **Implementation**: The parser uses Pratt parsing with binding power to handle operator precedence efficiently. The lexer uses numeric token types (const enum) and lookup tables for optimal performance.
 
@@ -29,7 +29,7 @@ The parser is implemented as a **hand-written Pratt parser** (precedence-climbin
 - Numeric const enum for token types (fast comparison)
 - O(1) character classification using Uint8Array lookup tables
 - Single-character token table for direct mapping
-- Manual string scanning (raw strings: `\'` escape only, quoted strings: full JSON escapes plus backtick)
+- Manual string scanning (raw strings: `\'` and `\\` unescaped by default, with legacy `\'`-only mode available; quoted strings: full JSON escapes plus backtick)
 - No regex for token matching - pure character-code scanning
 
 **Parser Key Components**:
@@ -68,7 +68,8 @@ npx jest test/parse.test.ts
 
 - `test/jmespath/*`: official `jmespath.test` fixtures.
 - `test/jmespath-community/*`: community deltas and additions.
-- Legacy literal fixtures (`test/jmespath-community/legacy/*`) run with `legacyLiterals` enabled in the compliance harness; other fixtures run in modern mode.
+- Core JMESPath fixtures (`test/jmespath/*`) run with compatibility options enabled: `legacyRawStringEscapes` (parser) and `legacyNullPropagation` (evaluation).
+- Legacy community literal fixtures (`test/jmespath-community/legacy/*`) run with `legacyLiterals` enabled; other community fixtures run in modern mode.
 
 **Supported Features**:
 
@@ -211,6 +212,7 @@ Benchmark implementation is modular:
 
 - Exports all public functions and types
 - Main entry points: `parseJsonSelector()`, `evaluateJsonSelector()`, `accessWithJsonSelector()`, `formatJsonSelector()`
+- Compatibility option types are public: `ParserOptions` (parse-time) and `EvaluationContext` (evaluation-time)
 
 ### Engineering Guardrails
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ Thank you for your interest in contributing to json-selector! This document prov
   - `parser.ts` - Hand-written Pratt parser
   - `ast.ts` - AST node type definitions
   - `evaluate.ts` - Selector evaluation logic
+  - `evaluation-context.ts` - Shared evaluation context type and compatibility options
   - `access.ts` - Read/write/delete accessors
   - `format.ts` - AST formatting back to selector strings
   - `visitor.ts` - Visitor pattern for AST traversal
@@ -116,10 +117,10 @@ Thank you for your interest in contributing to json-selector! This document prov
 ### Testing
 
 - Write tests for all new functionality
-- Aim for high code coverage
+- Maintain 100% code coverage for statements, branches, functions, and lines
 - Use descriptive test names
 - Test edge cases and error conditions
-- Current test status: 593/690 JMESPath compliance tests passing (85.9%)
+- Keep standards fixtures passing: `test/jmespath/*` (core) and `test/jmespath-community/*` (community)
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,6 @@
 # LoanCrate JSON Selectors
 
-LoanCrate JSON Selectors is a production-focused TypeScript implementation for querying and updating JSON documents with JMESPath-style expressions. It provides a hand-written Pratt parser, typed AST/visitor APIs, formatting back to expression strings, and read/write/delete accessors for mutating selected values.
-
-## Standards and Extensions
-
-- **Original [JMESPath](https://jmespath.org) spec**: fully implemented.
-- **[JMESPath Community Edition](https://jmespath.site/main/)**: implemented (community fixtures are maintained separately from core JMESPath fixtures).
-- **JSON Selector extension**: ID-based index shorthand (`x['id']`).
-- **JSON Selector extension**: bare numeric literals as general expressions (for example `a-1`, `-1`, `foo[?price > 0]`) in addition to backtick numeric literals.
-
-This includes JMESPath Community features such as root-node expressions (`$`), arithmetic expressions, and lexical-scope `let` expressions (`let $x = expr in expr`). In `let` expressions, binding values are evaluated in the outer scope, and `let`/`in` are contextual keywords (not reserved identifiers). The library passes all official [JMESPath compliance tests](https://github.com/jmespath/jmespath.test) (fixtures under `test/jmespath/*`) and maintains separate Community Edition compliance fixtures under `test/jmespath-community/*`.
-
-Backtick literals use modern (JEP-12a-style) behavior by default. Legacy backtick-literal compatibility is available via the `legacyLiterals` option (used for legacy community literal fixtures).
-
-To allow for selection by ID, we extend index expressions to accept a
-[raw string literal](https://jmespath.org/specification.html#raw-string-literals)
-(as opposed to a numeric literal), which represents the value of the `id` property
-of the desired object from an array of objects.
-Formally, `x['y']` would be equivalent to `x[?id == 'y'] | [0]` in JMESPath.
-This should be unambiguous relative to the existing grammar and semantics.
-
-To support arithmetic with bare numeric literals while preserving JMESPath-style
-negative index/slice syntax, `-` is always tokenized as an operator and resolved
-in the parser:
-
-- unary sign over numeric literals is folded at parse time (for example `-42`, `--1`)
-- subtraction in expression position remains standard (for example `a-1`)
-- negative index/slice values are parsed explicitly in bracket/slice grammar (for example `foo[-1]`, `foo[:-1]`)
-
-In addition to the extensions above, this library offers the following features compared to [jmespath.js](https://github.com/jmespath/jmespath.js):
-
-- Written using TypeScript with a hand-written Pratt parser
-- Type definitions for the abstract syntax tree (AST) produced by the parser
-- Typed visitor pattern for accessing AST nodes
-- Formatting of an AST back into an expression string
-- Read/write/delete accessors allow modification of the input data referenced by a selector
-- Detailed error reporting for syntax errors
+LoanCrate JSON Selectors is a production-focused TypeScript implementation for querying and updating JSON documents with JMESPath-style expressions. It emphasizes strict type-checking discipline and performance-focused execution, with typed AST/visitor APIs, formatting back to expression strings, and read/write/delete accessors for mutating selected values.
 
 ## Installation
 
@@ -71,34 +36,65 @@ accessor.delete();
 console.log(obj.foo.bar[0].value); // undefined
 ```
 
+## Standards and Extensions
+
+- **Original [JMESPath](https://jmespath.org) spec**: fully implemented.
+- **[JMESPath Community Edition](https://jmespath.site/main/)**: fully implemented (community fixtures are maintained separately from core JMESPath fixtures).
+- **JSON Selector extension**: ID-based index shorthand (`x['id']`).
+- **JSON Selector extension**: bare numeric literals as general expressions (for example `a-1`, `-1`, `foo[?price > 0]`) in addition to backtick numeric literals.
+
+This includes JMESPath Community features such as root-node expressions (`$`), arithmetic expressions, and lexical-scope `let` expressions (`let $x = expr in expr`). In `let` expressions, binding values are evaluated in the outer scope, and `let`/`in` are contextual keywords (not reserved identifiers). The library maintains full compliance with both official [JMESPath compliance tests](https://github.com/jmespath/jmespath.test) (`test/jmespath/*`) and JMESPath Community Edition fixtures (`test/jmespath-community/*`).
+
+Backtick literals use modern (JEP-12a-style) behavior by default. Legacy compatibility behavior is configurable via `ParserOptions` and `EvaluationContext`:
+
+- `legacyLiterals` (parser option): enables legacy backtick-literal fallback behavior.
+- `legacyRawStringEscapes` (parser option): enables legacy raw-string escaping where only `\'` is unescaped.
+- `legacyNullPropagation` (evaluation option): enables legacy null propagation for multi-select expressions (set via `evaluateJsonSelector(..., context, { legacyNullPropagation: true })`).
+
+By default, raw strings unescape both `\'` and `\\`, and multi-select expressions evaluate on `null` context per Community Edition semantics.
+
+To allow for selection by ID, we extend index expressions to accept a
+[raw string literal](https://jmespath.org/specification.html#raw-string-literals)
+(as opposed to a numeric literal), which represents the value of the `id` property
+of the desired object from an array of objects.
+Formally, `x['y']` would be equivalent to `x[?id == 'y'] | [0]` in JMESPath.
+This should be unambiguous relative to the existing grammar and semantics.
+
+To support arithmetic with bare numeric literals while preserving JMESPath-style
+negative index/slice syntax, `-` is always tokenized as an operator and resolved
+in the parser:
+
+- unary sign over numeric literals is folded at parse time (for example `-42`, `--1`)
+- subtraction in expression position remains standard (for example `a-1`)
+- negative index/slice values are parsed explicitly in bracket/slice grammar (for example `foo[-1]`, `foo[:-1]`)
+
+In addition to the extensions above, this library offers the following features compared to [jmespath.js](https://github.com/jmespath/jmespath.js):
+
+- Strict type-checking and runtime validation discipline across parser, evaluator, and functions
+- Performance-focused implementation with optimized parsing and benchmarking support
+- Type definitions for the abstract syntax tree (AST) produced by the parser
+- Typed visitor pattern for accessing AST nodes
+- Formatting of an AST back into an expression string
+- Read/write/delete accessors allow modification of the input data referenced by a selector
+- Detailed error reporting for syntax errors
+
 ## Operator Precedence
 
-As mentioned above, JSON Selectors are based on
-[JMESPath](https://jmespath.org). Although JMESPath claims to have an "ABNF
-grammar with a complete specification", the
-[specification](https://jmespath.org/specification.html) is not complete
-regarding operator precedence, since it only mentions the relative precedence of
-5 tokens (`|`, `||`, `&&`, `!`, and `]`). To discover the precedence of other
-operators, we must turn to the [JMESPath source
-code](https://github.com/jmespath/jmespath.js/blob/master/jmespath.js). It is
-implemented as a [Top-Down Operator Precedence (TDOP)
-parser](https://eli.thegreenplace.net/2010/01/02/top-down-operator-precedence-parsing),
-which is based on principles like "token binding power", "null denotation"
-(**nud**), and "left denotation" (**led**). Given knowledge of these principles
-and the [binding power
-table](https://github.com/jmespath/jmespath.js/blob/master/jmespath.js#L474-L501)
-from the source, we can reverse-engineer the operator precedence of JMESPath.
+JSON Selector expressions use deterministic precedence rules. When parentheses
+are omitted, operators bind from lowest to highest as listed below.
 
-The expression grammar has three categories of operators:
+The expression grammar has three main categories of operators:
 
-**Logical and comparison operators** follow traditional precedence rules (from
-lowest to highest):
+**Control, logical, comparison, and arithmetic operators** (lowest to highest):
 
 - pipe: `|`
+- ternary: `?:`
 - or: `||`
 - and: `&&`
 - compare: `<=`, `>=`, `<`, `>`, `==`, `!=`
-- not: `!` (prefix)
+- additive: `+`, `-`, `−`
+- multiplicative: `*`, `×`, `/`, `÷`, `%`, `//`
+- unary prefixes: `!`, unary `+`, unary `-`, unary `−`
 
 Higher-precedence operators bind more tightly. For example, `a || b && c`
 parses as `a || (b && c)`, and `a || b.c` parses as `a || (b.c)` because
@@ -118,14 +114,16 @@ chain step by step.
 
 - flatten: `[]` (flatten arrays)
 - filter: `[?condition]` (filter by condition)
-- star: `[*]` (map over array values)
+- array star: `[*]` (map over array values)
+- object star: `*`, `.*` (map over object values)
 
-Projections terminate before logical, comparison, and pipe operators, but
-continue with access operators and can chain with other projections. For
-example:
+Projections terminate before pipe, ternary, logical, comparison, and arithmetic
+operators, but continue with access operators and can chain with other
+projections. For example:
 
 - `items[*].name` - projects over items, accessing name from each
 - `items[*].tags[]` - projects over items, then flattens tags arrays
+- `obj.*.name` - projects over object values, then accesses `name` from each
 - `items[*] || []` - projection completes before the `||`, result is `(items[*]) || []`
 
 **Note on chained flattens**: Multiple flattens compound to flatten deeper

--- a/benchmark/compare.ts
+++ b/benchmark/compare.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-console */
 
 import { readFileSync } from "fs";
-import type { BenchmarkRun, ComparisonResult } from "./types";
+
 import { formatMicroseconds } from "./format";
+import type { BenchmarkRun, ComparisonResult } from "./types";
 
 export function loadBenchmarkRun(path: string): BenchmarkRun {
   const content = readFileSync(path, "utf-8");

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -2,6 +2,7 @@
 
 import { writeFileSync } from "fs";
 import { parseArgs } from "util";
+
 import { getCompatibleCases } from "./cases";
 import { compareRuns, loadBenchmarkRun, printComparison } from "./compare";
 import { categorizeResults, printAllResults, toJSON } from "./format";

--- a/benchmark/parsers.ts
+++ b/benchmark/parsers.ts
@@ -1,6 +1,8 @@
-import { parseJsonSelector } from "../src";
-import * as jmespath from "jmespath";
 import { compile as tsJmespathCompile } from "@jmespath-community/jmespath";
+import * as jmespath from "jmespath";
+
+import { parseJsonSelector } from "../src";
+
 import type { LibraryId } from "./types";
 
 // Extend jmespath types - @types/jmespath is incomplete

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -1,4 +1,6 @@
 import { execSync } from "child_process";
+
+import type { ParseFn } from "./parsers";
 import type {
   BenchmarkCase,
   BenchmarkConfig,
@@ -6,7 +8,6 @@ import type {
   BenchmarkResult,
   LibraryId,
 } from "./types";
-import type { ParseFn } from "./parsers";
 
 export function calculateStdDev(times: number[], avg: number): number {
   const variance =

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,6 +50,28 @@ export default [
     },
   },
   {
+    files: ["**/*.ts"],
+    plugins: { import: importPlugin },
+    rules: {
+      "import/order": [
+        "warn",
+        {
+          groups: [
+            "builtin",
+            "external",
+            "internal",
+            "parent",
+            "sibling",
+            "index",
+            "object",
+          ],
+          "newlines-between": "always",
+          alphabetize: { order: "asc", caseInsensitive: true },
+        },
+      ],
+    },
+  },
+  {
     files: ["src/**/*.ts"],
     plugins: { import: importPlugin },
     rules: {

--- a/src/access.ts
+++ b/src/access.ts
@@ -12,8 +12,8 @@ import {
   project,
   slice,
 } from "./evaluate";
+import type { EvaluationContext } from "./evaluation-context";
 import { formatJsonSelector } from "./format";
-import { EvaluationContext } from "./functions";
 import { getBuiltinFunctionProvider } from "./functions/builtins";
 import {
   asArray,

--- a/src/evaluation-context.ts
+++ b/src/evaluation-context.ts
@@ -1,0 +1,17 @@
+import type { FunctionProvider } from "./functions/provider";
+
+/**
+ * Immutable runtime evaluation scope shared across expression evaluation.
+ * This context is evaluation-only; parser/lexer compatibility options are
+ * configured separately via parse options.
+ */
+export type EvaluationContext = {
+  /** The root document (`$`). */
+  rootContext: unknown;
+  /** Function provider for built-in and custom functions. */
+  functionProvider: FunctionProvider;
+  /** Lexical-scope variable bindings (name without `$` -> value). */
+  bindings?: ReadonlyMap<string, unknown>;
+  /** Enables legacy null propagation for multi-select expressions. */
+  legacyNullPropagation?: boolean;
+};

--- a/src/functions/builtins/index.ts
+++ b/src/functions/builtins/index.ts
@@ -1,5 +1,6 @@
 import { FunctionProvider } from "../provider";
 import { FunctionDefinition } from "../types";
+
 import { registerArrayFunctions } from "./array";
 import { registerMathFunctions } from "./math";
 import { registerStringFunctions } from "./string";

--- a/src/functions/builtins/math.ts
+++ b/src/functions/builtins/math.ts
@@ -1,11 +1,11 @@
 import { isArray } from "../../util";
-import { FunctionDefinition } from "../types";
 import {
   NUMBER_ARRAY_TYPE,
   NUMBER_TYPE,
   STRING_ARRAY_TYPE,
   unionOf,
 } from "../datatype";
+import { FunctionDefinition } from "../types";
 import { arg } from "../validation";
 
 /** Registers all JMESPath numeric functions. */

--- a/src/functions/provider.ts
+++ b/src/functions/provider.ts
@@ -1,6 +1,7 @@
+import { UnknownFunctionError } from "../errors";
+
 import { makeExpressionRef } from "./datatype";
 import { FunctionArg, FunctionCallArgs, FunctionDefinition } from "./types";
-import { UnknownFunctionError } from "../errors";
 import { validateArguments } from "./validation";
 
 /** Immutable lookup table mapping function names to their {@link FunctionDefinition}s. */

--- a/src/functions/registry.ts
+++ b/src/functions/registry.ts
@@ -1,5 +1,5 @@
-import { FallbackMapView } from "./FallbackMapView";
 import { getBuiltinFunctionProvider } from "./builtins";
+import { FallbackMapView } from "./FallbackMapView";
 import { FunctionProvider } from "./provider";
 import { FunctionDefinition } from "./types";
 

--- a/src/functions/types.ts
+++ b/src/functions/types.ts
@@ -1,21 +1,8 @@
 import { JsonSelector } from "../ast";
+import type { EvaluationContext } from "../evaluation-context";
 import { NonEmptyArray } from "../util";
-import { DataType } from "./datatype";
-import type { FunctionProvider } from "./provider";
 
-/**
- * Immutable evaluation scope: the root document and function registry.
- */
-export type EvaluationContext = {
-  /** The root document (`$`). */
-  rootContext: unknown;
-  /** Function provider for built-in and custom functions. */
-  functionProvider: FunctionProvider;
-  /** Lexical-scope variable bindings (name without `$` -> value). */
-  bindings?: ReadonlyMap<string, unknown>;
-  /** Enables legacy backtick-literal fallback behavior (non-JSON content parsed as string). */
-  legacyLiterals?: boolean;
-};
+import { DataType } from "./datatype";
 
 /**
  * Common evaluation context shared by function call and handler bindings.

--- a/src/functions/validation.ts
+++ b/src/functions/validation.ts
@@ -1,9 +1,10 @@
-import { NonEmptyArray } from "../util";
 import {
   InvalidArgumentTypeError,
   InvalidArgumentValueError,
   InvalidArityError,
 } from "../errors";
+import { NonEmptyArray } from "../util";
+
 import { DataType, formatType, getDataType, matchesType } from "./datatype";
 import { ArgumentSignature, FunctionArg } from "./types";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 export * from "./access";
 export * from "./ast";
 export * from "./errors";
+export * from "./evaluation-context";
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- re-exporting; only one overload is deprecated
 export { evaluateJsonSelector } from "./evaluate";
 export * from "./format";
 export * from "./functions";
 export * from "./get";
 export * from "./parse";
+export type { ParserOptions } from "./parser";
 export * from "./set";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,5 @@
 import { JsonValue } from "type-fest";
+
 import {
   JsonSelector,
   JsonSelectorArithmeticOperator,
@@ -21,11 +22,6 @@ const CURRENT_NODE: Readonly<JsonSelectorCurrent> = Object.freeze({
 const ROOT_NODE: Readonly<JsonSelectorRoot> = Object.freeze({
   type: "root",
 });
-
-export interface ParserOptions {
-  /** Enables legacy backtick-literal fallback behavior (`\`foo\`` -> `"foo"`). */
-  legacyLiterals?: boolean;
-}
 
 // Binding power constants (higher = tighter binding)
 const BP_PIPE = 1;
@@ -91,8 +87,15 @@ const TOKEN_BP: number[] = (() => {
   return bp;
 })();
 
+export interface ParserOptions {
+  /** Enables legacy backtick-literal fallback behavior (`\`foo\`` -> `"foo"`). */
+  legacyLiterals?: boolean;
+  /** Enables legacy raw-string escapes (only \' is unescaped). */
+  legacyRawStringEscapes?: boolean;
+}
+
 /**
- * Pratt Parser for JSON Selectors
+ * Hand-written parser for JSON Selectors.
  *
  * Uses precedence-climbing (Pratt parsing) with binding power (0-55 range) to handle
  * operator precedence efficiently. The parser uses two main methods:
@@ -106,7 +109,9 @@ export class Parser {
 
   constructor(input: string, options?: ParserOptions) {
     this.input = input;
-    this.lexer = new Lexer(input);
+    this.lexer = new Lexer(input, {
+      legacyRawStringEscapes: options?.legacyRawStringEscapes,
+    });
     this.legacyLiterals = options?.legacyLiterals === true;
   }
 

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -12,6 +12,7 @@ import {
   UnexpectedTokenError,
   UnknownFunctionError,
 } from "../src";
+
 import { catchError } from "./helpers";
 
 describe("error hierarchy", () => {

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -1,6 +1,7 @@
 import { evaluateJsonSelector, project } from "../src/evaluate";
 import { getBuiltinFunctionProvider } from "../src/functions/builtins";
 import { parseJsonSelector } from "../src/parse";
+
 import { catchError } from "./helpers";
 
 describe("evaluate", () => {
@@ -70,14 +71,31 @@ describe("evaluate", () => {
     expect(evaluateJsonSelector(selector, { foo: "bar" })).toBeNull();
   });
 
-  test("multiSelectList returns null for null context", () => {
+  test("multiSelectList evaluates against null context", () => {
     const selector = parseJsonSelector("[a, b]");
-    expect(evaluateJsonSelector(selector, null)).toBeNull();
+    expect(evaluateJsonSelector(selector, null)).toStrictEqual([null, null]);
   });
 
-  test("multiSelectHash returns null for null context", () => {
+  test("multiSelectList returns null in legacy null-propagation mode", () => {
+    const selector = parseJsonSelector("[a, b]");
+    expect(
+      evaluateJsonSelector(selector, null, { legacyNullPropagation: true }),
+    ).toBeNull();
+  });
+
+  test("multiSelectHash evaluates against null context", () => {
     const selector = parseJsonSelector("{x: a, y: b}");
-    expect(evaluateJsonSelector(selector, null)).toBeNull();
+    expect(evaluateJsonSelector(selector, null)).toStrictEqual({
+      x: null,
+      y: null,
+    });
+  });
+
+  test("multiSelectHash returns null in legacy null-propagation mode", () => {
+    const selector = parseJsonSelector("{x: a, y: b}");
+    expect(
+      evaluateJsonSelector(selector, null, { legacyNullPropagation: true }),
+    ).toBeNull();
   });
 
   test("objectProject on non-object returns null", () => {

--- a/test/functions/array.test.ts
+++ b/test/functions/array.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+
 import { InvalidArgumentTypeError } from "../../src/errors";
 import { getBuiltinFunctionProvider } from "../../src/functions/builtins";
 import { makeExpressionRef } from "../../src/functions/datatype";
@@ -24,8 +25,24 @@ describe("array functions", () => {
     expect(evaluate("sort(@)", [10, 3, 1, 2])).toStrictEqual([1, 2, 3, 10]);
   });
 
+  test("sort numbers with equal values", () => {
+    expect(evaluate("sort(@)", [2, 1, 2])).toStrictEqual([1, 2, 2]);
+  });
+
   test("sort strings", () => {
     expect(evaluate("sort(@)", ["c", "a", "b"])).toStrictEqual(["a", "b", "c"]);
+  });
+
+  test("sort strings with shared prefixes", () => {
+    expect(evaluate("sort(@)", ["ab", "a"])).toStrictEqual(["a", "ab"]);
+  });
+
+  test("sort strings with shared astral prefixes", () => {
+    expect(evaluate("sort(@)", ["𝌆b", "𝌆a"])).toStrictEqual(["𝌆a", "𝌆b"]);
+  });
+
+  test("sort strings with identical values", () => {
+    expect(evaluate("sort(@)", ["a", "a"])).toStrictEqual(["a", "a"]);
   });
 
   test("sort uses codepoint ordering (uppercase before lowercase)", () => {

--- a/test/functions/math.test.ts
+++ b/test/functions/math.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+
 import { getBuiltinFunctionProvider } from "../../src/functions/builtins";
 import { FunctionProvider } from "../../src/functions/provider";
 import { evaluate } from "../helpers";

--- a/test/functions/registry.test.ts
+++ b/test/functions/registry.test.ts
@@ -2,8 +2,8 @@ import { evaluateJsonSelector } from "../../src/evaluate";
 import { FunctionRegistry } from "../../src/functions";
 import { getBuiltinFunctionProvider } from "../../src/functions/builtins";
 import { ANY_TYPE, NUMBER_TYPE } from "../../src/functions/datatype";
-import { parseJsonSelector } from "../../src/parse";
 import { arg } from "../../src/functions/validation";
+import { parseJsonSelector } from "../../src/parse";
 
 describe("FunctionRegistry", () => {
   test("register and call custom function", () => {

--- a/test/functions/string.test.ts
+++ b/test/functions/string.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+
 import { InvalidArgumentValueError } from "../../src/errors";
 import { getBuiltinFunctionProvider } from "../../src/functions/builtins";
 import { FunctionProvider } from "../../src/functions/provider";
@@ -25,6 +26,10 @@ describe("string functions", () => {
 
   test("length of object", () => {
     expect(evaluate("length(@)", { a: 1, b: 2 })).toBe(2);
+  });
+
+  test("length handles unpaired high surrogate as one code point", () => {
+    expect(evaluate("length(@)", "\ud800a")).toBe(2);
   });
 
   test("reverse of array", () => {
@@ -167,6 +172,10 @@ describe("string functions", () => {
     expect(evaluate("find_first(@, 'o', `0`, `1`)", "foobar")).toBeNull();
   });
 
+  test("find_first with negative end", () => {
+    expect(evaluate("find_first(@, 'o', `0`, `-2`)", "foobar")).toBe(1);
+  });
+
   test("find_last", () => {
     expect(evaluate("find_last(@, 'o')", "foobar")).toBe(2);
     expect(evaluate("find_last(@, 'xyz')", "foobar")).toBeNull();
@@ -174,6 +183,10 @@ describe("string functions", () => {
 
   test("find_last with start and end", () => {
     expect(evaluate("find_last(@, 'o', `0`, `2`)", "foobar")).toBe(1);
+  });
+
+  test("find_last with negative end", () => {
+    expect(evaluate("find_last(@, 'o', `0`, `-2`)", "foobar")).toBe(2);
   });
 
   test("find_first throws for non-integer start", () => {
@@ -252,6 +265,14 @@ describe("string functions", () => {
     expect(() => evaluate("split(@, ',', `-1`)", "a,b,c")).toThrow(
       InvalidArgumentValueError,
     );
+  });
+
+  test("split with empty delimiter and large count returns characters", () => {
+    expect(evaluate("split(@, '', `10`)", "abc")).toStrictEqual([
+      "a",
+      "b",
+      "c",
+    ]);
   });
 });
 

--- a/test/jmespath.test.ts
+++ b/test/jmespath.test.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
+
 import { JsonValue } from "type-fest";
+
 import {
   type EvaluationContext,
   evaluateJsonSelector,
@@ -9,6 +11,7 @@ import {
   InvalidArityError,
   JsonSelectorSyntaxError,
   parseJsonSelector,
+  ParserOptions,
   UndefinedVariableError,
   UnknownFunctionError,
 } from "../src";
@@ -23,91 +26,6 @@ const ERROR_TYPE_MAP: Record<string, new (...args: any[]) => Error> = {
   "undefined-variable": UndefinedVariableError,
 };
 
-const include = new Set<string>();
-const exclude = new Set<string>();
-
-const excludeComments: Array<string | RegExp> = [];
-
-const excludeExpressions: Array<string | RegExp> = [];
-
-const deferredCommunityCases: Array<{
-  file: RegExp;
-  comment?: string | RegExp;
-  expression?: string | RegExp;
-}> = [
-  // Deferred: JMESPath Community string function semantics.
-  {
-    file: /test\/jmespath-community\/functions_strings\.json$/,
-    expression: "find_first(string, 'string', `-6`)",
-  },
-  {
-    file: /test\/jmespath-community\/functions_strings\.json$/,
-    expression: "find_first(string, 'string', `-99`, `100`)",
-  },
-  {
-    file: /test\/jmespath-community\/functions_strings\.json$/,
-    expression: "find_first(string, '')",
-  },
-  {
-    file: /test\/jmespath-community\/functions_strings\.json$/,
-    expression: "find_first('', '')",
-  },
-  {
-    file: /test\/jmespath-community\/functions_strings\.json$/,
-    expression: "find_last(string, 's', `-6`)",
-  },
-  {
-    file: /test\/jmespath-community\/functions_strings\.json$/,
-    expression: "find_last(string, '')",
-  },
-  {
-    file: /test\/jmespath-community\/functions_strings\.json$/,
-    expression: "find_last('', '')",
-  },
-  {
-    file: /test\/jmespath-community\/functions_strings\.json$/,
-    expression: /trim\('[\s\S]*\u2000[\s\S]*'\)/u,
-  },
-  {
-    file: /test\/jmespath-community\/functions_strings\.json$/,
-    expression: "split('all chars', '', `3`)",
-  },
-
-  // Deferred: literal-grammar/raw-string community deltas.
-  {
-    file: /test\/jmespath-community\/literal\.json$/,
-    comment: "Can escape backslash",
-  },
-
-  // Deferred: projection/pipe community semantics on null and string slices.
-  {
-    file: /test\/jmespath-community\/pipe\.json$/,
-    expression: "`null`|[@]",
-  },
-  {
-    file: /test\/jmespath-community\/pipe\.json$/,
-    expression: "`null`|{foo: @}",
-  },
-  {
-    file: /test\/jmespath-community\/slice\.json$/,
-    expression: "'foo'[:].length(@)",
-  },
-
-  // Deferred: Unicode collation/grapheme semantics.
-  {
-    file: /test\/jmespath-community\/unicode\.json$/,
-    expression: "length('𝌆')",
-  },
-  {
-    file: /test\/jmespath-community\/unicode\.json$/,
-    expression: "sort(strings)",
-  },
-  {
-    file: /test\/jmespath-community\/unicode\.json$/,
-    expression: "sort_by(graphemeClusters, &string)",
-  },
-];
-
 const fixtureDirs = ["test/jmespath", "test/jmespath-community"];
 
 for (const dirname of fixtureDirs) {
@@ -117,16 +35,7 @@ for (const dirname of fixtureDirs) {
   }
   const files = listJsonFiles(dirname);
   for (const pathname of files) {
-    const { name, ext } = path.parse(pathname);
-    if (
-      ext === ".json" &&
-      (!include.size || include.has(name)) &&
-      !exclude.has(name)
-    ) {
-      addTestSuitesFromFile(pathname);
-    } else {
-      describe.skip(pathname, () => undefined);
-    }
+    addTestSuitesFromFile(pathname);
   }
 }
 
@@ -156,8 +65,13 @@ interface ErrorTestCase {
   error: string;
 }
 
+interface SearchOptions {
+  evalCtx?: Partial<EvaluationContext>;
+  parserOptions?: ParserOptions;
+}
+
 function addTestSuitesFromFile(filename: string) {
-  const evalCtx = getFixtureEvalContext(filename);
+  const options = getFixtureSearchOptions(filename);
   describe(filename, function () {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const suites = JSON.parse(
@@ -175,34 +89,26 @@ function addTestSuitesFromFile(filename: string) {
           const testName = `Test #${testNumber}: ${
             testCase.comment || testCase.expression
           }`;
-          if (
-            !excludeComments.some((p) => matches(testCase.comment, p)) &&
-            !excludeExpressions.some((p) => matches(testCase.expression, p)) &&
-            !isDeferredCommunityCase(filename, testCase)
-          ) {
-            if ("error" in testCase) {
-              it(testName, function () {
-                const ErrorClass = ERROR_TYPE_MAP[testCase.error];
-                if (ErrorClass) {
-                  expect(() =>
-                    search(given, testCase.expression, evalCtx),
-                  ).toThrow(ErrorClass);
-                } else {
-                  expect(() =>
-                    search(given, testCase.expression, evalCtx),
-                  ).toThrow();
-                }
-              });
-            } else {
-              it(testName, function () {
-                const result = search(given, testCase.expression, evalCtx);
-                if ("result" in testCase) {
-                  expect(result).toStrictEqual(testCase.result);
-                }
-              });
-            }
+          if ("error" in testCase) {
+            it(testName, function () {
+              const ErrorClass = ERROR_TYPE_MAP[testCase.error];
+              if (ErrorClass) {
+                expect(() =>
+                  search(given, testCase.expression, options),
+                ).toThrow(ErrorClass);
+              } else {
+                expect(() =>
+                  search(given, testCase.expression, options),
+                ).toThrow();
+              }
+            });
           } else {
-            it.skip(testName, () => undefined);
+            it(testName, function () {
+              const result = search(given, testCase.expression, options);
+              if ("result" in testCase) {
+                expect(result).toStrictEqual(testCase.result);
+              }
+            });
           }
           ++testNumber;
         }
@@ -212,25 +118,17 @@ function addTestSuitesFromFile(filename: string) {
   });
 }
 
-function getFixtureEvalContext(
-  filename: string,
-): Partial<EvaluationContext> | undefined {
+function getFixtureSearchOptions(filename: string): SearchOptions | undefined {
+  if (/test\/jmespath\//.test(filename)) {
+    return {
+      evalCtx: { legacyNullPropagation: true },
+      parserOptions: { legacyRawStringEscapes: true },
+    };
+  }
   if (/test\/jmespath-community\/legacy\//.test(filename)) {
-    return { legacyLiterals: true };
+    return { parserOptions: { legacyLiterals: true } };
   }
   return undefined;
-}
-
-function isDeferredCommunityCase(
-  filename: string,
-  testCase: TestCase,
-): boolean {
-  return deferredCommunityCases.some(
-    ({ file, comment, expression }) =>
-      file.test(filename) &&
-      (comment === undefined || matches(testCase.comment, comment)) &&
-      (expression === undefined || matches(testCase.expression, expression)),
-  );
 }
 
 function listJsonFiles(dirname: string): string[] {
@@ -247,21 +145,14 @@ function listJsonFiles(dirname: string): string[] {
   return files;
 }
 
-function matches(s: string | undefined, pattern: string | RegExp): boolean {
-  return (
-    s != null &&
-    (typeof pattern === "string" ? s.includes(pattern) : pattern.test(s))
-  );
-}
-
 function search(
   value: JsonValue,
   expression: string,
-  evalCtx?: Partial<EvaluationContext>,
+  options?: SearchOptions,
 ): unknown {
   return evaluateJsonSelector(
-    parseJsonSelector(expression, { legacyLiterals: evalCtx?.legacyLiterals }),
+    parseJsonSelector(expression, options?.parserOptions),
     value,
-    evalCtx,
+    options?.evalCtx,
   );
 }

--- a/test/lexer.test.ts
+++ b/test/lexer.test.ts
@@ -1,12 +1,13 @@
-import { Lexer } from "../src/lexer";
+import { Lexer, type LexerOptions } from "../src/lexer";
 import { describeTokenType, Token, TokenType } from "../src/token";
+
 import { catchError } from "./helpers";
 
 /**
  * Collect all tokens from input (excluding EOF).
  */
-function tokens(input: string): Token[] {
-  const lexer = new Lexer(input);
+function tokens(input: string, options?: LexerOptions): Token[] {
+  const lexer = new Lexer(input, options);
   const result: Token[] = [];
   let token = lexer.peek();
   while (token.type !== TokenType.EOF) {
@@ -19,8 +20,8 @@ function tokens(input: string): Token[] {
 /**
  * Get a single token from input (for simple value testing).
  */
-function tokenize(input: string): Token {
-  const lexer = new Lexer(input);
+function tokenize(input: string, options?: LexerOptions): Token {
+  const lexer = new Lexer(input, options);
   return lexer.peek();
 }
 
@@ -203,6 +204,22 @@ describe("Lexer", () => {
         expect(tokenize("''")).toMatchObject({
           type: TokenType.RAW_STRING,
           value: "",
+        });
+      });
+
+      test("unescapes \\\\ in raw strings by default", () => {
+        expect(tokenize(String.raw`'\\'`)).toMatchObject({
+          type: TokenType.RAW_STRING,
+          value: "\\",
+        });
+      });
+
+      test("keeps \\\\ in raw strings in legacyRawStringEscapes mode", () => {
+        expect(
+          tokenize(String.raw`'\\'`, { legacyRawStringEscapes: true }),
+        ).toMatchObject({
+          type: TokenType.RAW_STRING,
+          value: "\\\\",
         });
       });
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
+
 import { JsonSelector } from "../src/ast";
 import { parseJsonSelector } from "../src/parse";
+
 import { catchError } from "./helpers";
 
 describe("parseJsonSelector", () => {
@@ -579,6 +581,22 @@ describe("parseJsonSelector", () => {
       expect(parseJsonSelector("'hello'")).toStrictEqual<JsonSelector>({
         type: "literal",
         value: "hello",
+      });
+    });
+
+    test("raw string unescapes \\\\ by default", () => {
+      expect(parseJsonSelector(String.raw`'\\'`)).toStrictEqual<JsonSelector>({
+        type: "literal",
+        value: "\\",
+      });
+    });
+
+    test("raw string preserves \\\\ in legacyRawStringEscapes mode", () => {
+      expect(
+        parseJsonSelector(String.raw`'\\'`, { legacyRawStringEscapes: true }),
+      ).toStrictEqual<JsonSelector>({
+        type: "literal",
+        value: "\\\\",
       });
     });
 


### PR DESCRIPTION
Resolves [LC-16708](https://linear.app/loancrate/issue/LC-16708/fix-remaining-jmespath-community-edition-compliance-failures)

## Summary

- Achieves full JMESPath Community Edition compliance by fixing all previously deferred test cases
- Adds Unicode-aware string operations: `length()` counts code points, `sort()`/`sort_by()` use code-point comparison, `split("")` iterates by code points, and `trim` handles Unicode whitespace (U+0085)
- Introduces configurable compatibility modes: `legacyRawStringEscapes` (parser) and `legacyNullPropagation` (evaluation) to toggle between original JMESPath and Community Edition behavior
- Extracts `EvaluationContext` to its own file (`src/evaluation-context.ts`) to break circular dependencies and separate parse-time from evaluation-time options
- Implements Community Edition null-propagation semantics for multi-select expressions and string projection support
- Adds `eslint-plugin-import` ordering rule to enforce consistent import grouping (builtin → external → internal) and alphabetical sorting, preventing unnecessary diffs from import order churn going forward

## Test plan

- [x] All 2,359 JMESPath and JMESPath Community compliance tests pass
- [x] Core JMESPath fixtures run with legacy compatibility options enabled
- [x] New unit tests cover Unicode edge cases (unpaired surrogates, astral characters, code-point sorting)
- [x] 100% code coverage maintained
- [x] ESLint passes cleanly