### PR TITLE
LC-16709: Add comprehensive reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # LoanCrate JSON Selectors
 
-LoanCrate JSON Selectors is a production-focused TypeScript implementation for querying and updating JSON documents with JMESPath-style expressions. It emphasizes strict type-checking discipline and performance-focused execution, with typed AST/visitor APIs, formatting back to expression strings, and read/write/delete accessors for mutating selected values.
+A TypeScript library for querying and mutating JSON documents using [JMESPath](https://jmespath.org)-style expressions. Fully implements both the original JMESPath specification and [JMESPath Community Edition](https://jmespath.site/main/), with two extensions for ID-based access and bare numeric literals.
+
+Key capabilities:
+
+- **Parse** expression strings into a typed AST
+- **Evaluate** selectors against JSON data
+- **Format** ASTs back into expression strings (round-trip safe)
+- **Read/write/delete** values via selector-based accessors
+- **Extend** with custom functions via a pluggable registry
 
 ## Installation
 
@@ -8,7 +16,7 @@ LoanCrate JSON Selectors is a production-focused TypeScript implementation for q
 npm add @loancrate/json-selector
 ```
 
-## Usage
+## Quick Start
 
 ```ts
 import {
@@ -36,102 +44,23 @@ accessor.delete();
 console.log(obj.foo.bar[0].value); // undefined
 ```
 
+## Documentation
+
+- [**Language Reference**](docs/language.md) — Expression syntax, operators, precedence, projections, and extensions
+- [**Function Reference**](docs/functions.md) — All 43 built-in functions with signatures and behavior
+- [**API Reference**](docs/api.md) — TypeScript exports, accessors, visitor, function system, errors, and AST
+- [**Benchmarks**](docs/benchmark.md) — Parsing performance benchmarks and cross-library comparison
+
 ## Standards and Extensions
 
-- **Original [JMESPath](https://jmespath.org) spec**: fully implemented.
-- **[JMESPath Community Edition](https://jmespath.site/main/)**: fully implemented (community fixtures are maintained separately from core JMESPath fixtures).
-- **JSON Selector extension**: ID-based index shorthand (`x['id']`).
-- **JSON Selector extension**: bare numeric literals as general expressions (for example `a-1`, `-1`, `foo[?price > 0]`) in addition to backtick numeric literals.
+The library fully implements the original [JMESPath specification](https://jmespath.org) and [JMESPath Community Edition](https://jmespath.site/main/), including root-node expressions (`$`), arithmetic, ternary conditionals, and lexical-scope `let` expressions. Compliance is verified against both official [JMESPath test fixtures](https://github.com/jmespath/jmespath.test) and JMESPath Community Edition fixtures.
 
-This includes JMESPath Community features such as root-node expressions (`$`), arithmetic expressions, and lexical-scope `let` expressions (`let $x = expr in expr`). In `let` expressions, binding values are evaluated in the outer scope, and `let`/`in` are contextual keywords (not reserved identifiers). The library maintains full compliance with both official [JMESPath compliance tests](https://github.com/jmespath/jmespath.test) (`test/jmespath/*`) and JMESPath Community Edition fixtures (`test/jmespath-community/*`).
+Two extensions are added:
 
-Backtick literals use modern (JEP-12a-style) behavior by default. Legacy compatibility behavior is configurable via `ParserOptions` and `EvaluationContext`:
+- **ID-based access**: `x['id']` selects the first array element whose `id` property matches — equivalent to `x[?id == 'id'] | [0]` in standard JMESPath.
+- **Bare numeric literals**: Numbers like `0`, `-1`, `3.14` can appear directly in expressions without backtick delimiters, enabling natural syntax like `foo[?price > 0]` and `a - 1`.
 
-- `legacyLiterals` (parser option): enables legacy backtick-literal fallback behavior.
-- `legacyRawStringEscapes` (parser option): enables legacy raw-string escaping where only `\'` is unescaped.
-- `legacyNullPropagation` (evaluation option): enables legacy null propagation for multi-select expressions (set via `evaluateJsonSelector(..., context, { legacyNullPropagation: true })`).
-
-By default, raw strings unescape both `\'` and `\\`, and multi-select expressions evaluate on `null` context per Community Edition semantics.
-
-To allow for selection by ID, we extend index expressions to accept a
-[raw string literal](https://jmespath.org/specification.html#raw-string-literals)
-(as opposed to a numeric literal), which represents the value of the `id` property
-of the desired object from an array of objects.
-Formally, `x['y']` would be equivalent to `x[?id == 'y'] | [0]` in JMESPath.
-This should be unambiguous relative to the existing grammar and semantics.
-
-To support arithmetic with bare numeric literals while preserving JMESPath-style
-negative index/slice syntax, `-` is always tokenized as an operator and resolved
-in the parser:
-
-- unary sign over numeric literals is folded at parse time (for example `-42`, `--1`)
-- subtraction in expression position remains standard (for example `a-1`)
-- negative index/slice values are parsed explicitly in bracket/slice grammar (for example `foo[-1]`, `foo[:-1]`)
-
-In addition to the extensions above, this library offers the following features compared to [jmespath.js](https://github.com/jmespath/jmespath.js):
-
-- Strict type-checking and runtime validation discipline across parser, evaluator, and functions
-- Performance-focused implementation with optimized parsing and benchmarking support
-- Type definitions for the abstract syntax tree (AST) produced by the parser
-- Typed visitor pattern for accessing AST nodes
-- Formatting of an AST back into an expression string
-- Read/write/delete accessors allow modification of the input data referenced by a selector
-- Detailed error reporting for syntax errors
-
-## Operator Precedence
-
-JSON Selector expressions use deterministic precedence rules. When parentheses
-are omitted, operators bind from lowest to highest as listed below.
-
-The expression grammar has three main categories of operators:
-
-**Control, logical, comparison, and arithmetic operators** (lowest to highest):
-
-- pipe: `|`
-- ternary: `?:`
-- or: `||`
-- and: `&&`
-- compare: `<=`, `>=`, `<`, `>`, `==`, `!=`
-- additive: `+`, `-`, `−`
-- multiplicative: `*`, `×`, `/`, `÷`, `%`, `//`
-- unary prefixes: `!`, unary `+`, unary `-`, unary `−`
-
-Higher-precedence operators bind more tightly. For example, `a || b && c`
-parses as `a || (b && c)`, and `a || b.c` parses as `a || (b.c)` because
-access operators have higher precedence than `||`.
-
-**Access operators** chain left-to-right as postfix operators:
-
-- member access: `.field`
-- index access: `[0]`, `[n:m]` (slices)
-- ID access: `['id']` (shorthand for `[?id == 'id'] | [0]`)
-
-For example, `a[0].b.c['id'].d.e` parses as `(((((a[0]).b).c)['id']).d).e` -
-each operator applies to the complete expression on its left, building up the
-chain step by step.
-
-**Projection operators** create projections that map over collections:
-
-- flatten: `[]` (flatten arrays)
-- filter: `[?condition]` (filter by condition)
-- array star: `[*]` (map over array values)
-- object star: `*`, `.*` (map over object values)
-
-Projections terminate before pipe, ternary, logical, comparison, and arithmetic
-operators, but continue with access operators and can chain with other
-projections. For example:
-
-- `items[*].name` - projects over items, accessing name from each
-- `items[*].tags[]` - projects over items, then flattens tags arrays
-- `obj.*.name` - projects over object values, then accesses `name` from each
-- `items[*] || []` - projection completes before the `||`, result is `(items[*]) || []`
-
-**Note on chained flattens**: Multiple flattens compound to flatten deeper
-levels. For example, on data `[[[1,2]], [[3,4]]]`:
-
-- `[]` gives `[[1,2], [3,4]]` (one level)
-- `[][]` gives `[1,2,3,4]` (two levels)
-- `[*][]` gives `[[1,2], [3,4]]` (projects then flattens once - not the same as `[][]`)
+Legacy compatibility options (`legacyLiterals`, `legacyRawStringEscapes`, `legacyNullPropagation`) are available for original JMESPath behavior. See the [Language Reference](docs/language.md#legacy-compatibility) for details.
 
 ## License
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,485 @@
+# API Reference
+
+TypeScript API for `@loancrate/json-selector`.
+
+## Summary
+
+### Core Functions
+
+| Export                                          | Description                                 |
+| ----------------------------------------------- | ------------------------------------------- |
+| [`parseJsonSelector`](#parsejsonselector)       | Parse an expression string into an AST      |
+| [`evaluateJsonSelector`](#evaluatejsonselector) | Evaluate a parsed selector against data     |
+| [`formatJsonSelector`](#formatjsonselector)     | Convert an AST back to an expression string |
+
+### Accessor Functions
+
+| Export                                                  | Description                                         |
+| ------------------------------------------------------- | --------------------------------------------------- |
+| [`accessWithJsonSelector`](#accesswithjsonselector)     | Parse, compile, and bind a selector in one step     |
+| [`makeJsonSelectorAccessor`](#makejsonselectoraccessor) | Compile a selector into a reusable unbound accessor |
+| [`bindJsonSelectorAccessor`](#bindjsonselectoraccessor) | Bind an unbound accessor to a context               |
+| [`getWithJsonSelector`](#getwithjsonselector)           | Read-only convenience wrapper                       |
+| [`setWithJsonSelector`](#setwithjsonselector)           | Write convenience wrapper                           |
+
+### Visitor
+
+| Export                                    | Description                                     |
+| ----------------------------------------- | ----------------------------------------------- |
+| [`visitJsonSelector`](#visitjsonselector) | Dispatch to a visitor method based on node type |
+| [`Visitor<R, C>`](#visitor-interface)     | Interface for AST traversal                     |
+
+### Function System
+
+| Export                                                      | Description                                               |
+| ----------------------------------------------------------- | --------------------------------------------------------- |
+| [`FunctionRegistry`](#functionregistry)                     | Register and manage custom functions                      |
+| [`getBuiltinFunctionProvider`](#getbuiltinfunctionprovider) | Access the built-in function table                        |
+| [Type constants](#type-constants)                           | `ANY_TYPE`, `NUMBER_TYPE`, `STRING_TYPE`, etc.            |
+| [Signature helpers](#signature-helpers)                     | `arg()`, `optArg()`, `varArg()`                           |
+| [Type utilities](#type-utilities)                           | `matchesType()`, `formatType()`, `arrayOf()`, `unionOf()` |
+
+### Errors
+
+| Export                                        | Description                           |
+| --------------------------------------------- | ------------------------------------- |
+| [`JsonSelectorError`](#error-hierarchy)       | Base class for all library errors     |
+| [`JsonSelectorSyntaxError`](#syntax-errors)   | Base class for parse-time errors      |
+| [`JsonSelectorRuntimeError`](#runtime-errors) | Base class for evaluation-time errors |
+
+### AST
+
+| Export                                   | Description                                      |
+| ---------------------------------------- | ------------------------------------------------ |
+| [`JsonSelector`](#ast-reference)         | Discriminated union of all AST node types        |
+| [`JsonSelectorNodeType`](#ast-reference) | String literal union of node type discriminators |
+
+---
+
+## Core Functions
+
+### `parseJsonSelector`
+
+```ts
+function parseJsonSelector(
+  selectorExpression: string,
+  options?: ParserOptions,
+): JsonSelector;
+```
+
+Parses an expression string into an AST. Throws a `JsonSelectorSyntaxError` subclass on invalid input.
+
+**`ParserOptions`**
+
+| Field                    | Type      | Default | Description                                                             |
+| ------------------------ | --------- | ------- | ----------------------------------------------------------------------- |
+| `legacyLiterals`         | `boolean` | `false` | Enable legacy backtick-literal fallback (invalid JSON becomes a string) |
+| `legacyRawStringEscapes` | `boolean` | `false` | Only unescape `\'` in raw strings (not `\\`)                            |
+
+### `evaluateJsonSelector`
+
+```ts
+function evaluateJsonSelector(
+  selector: JsonSelector,
+  context: unknown,
+  evalCtx?: Partial<EvaluationContext>,
+): unknown;
+```
+
+Evaluates a parsed selector against `context` and returns the result. The optional `evalCtx` provides runtime configuration.
+
+**`EvaluationContext`**
+
+| Field                   | Type                           | Default            | Description                                                 |
+| ----------------------- | ------------------------------ | ------------------ | ----------------------------------------------------------- |
+| `rootContext`           | `unknown`                      | `context`          | The root document, accessible via `$`                       |
+| `functionProvider`      | `FunctionProvider`             | Built-in functions | Function lookup table                                       |
+| `bindings`              | `ReadonlyMap<string, unknown>` | —                  | Pre-bound lexical variables                                 |
+| `legacyNullPropagation` | `boolean`                      | `false`            | Multi-select on `null` returns `null` instead of evaluating |
+
+A deprecated overload accepting `(selector, context, rootContext, options)` still exists for backward compatibility.
+
+### `formatJsonSelector`
+
+```ts
+function formatJsonSelector(selector: JsonSelector): string;
+```
+
+Converts an AST back into an expression string. Preserves syntax hints: backtick literals remain backtick-delimited, bare numeric literals stay bare. The output is always valid syntax that can be re-parsed to an equivalent AST.
+
+---
+
+## Accessor Functions
+
+Accessors provide `get()`, `set()`, and `delete()` operations on JSON data identified by a selector. The system uses a two-phase approach:
+
+1. **Compile** (`makeJsonSelectorAccessor`) — produces an `UnboundAccessor` from a selector AST. This can be done once and reused.
+2. **Bind** (`bindJsonSelectorAccessor`) — binds the accessor to a specific context object, producing an `Accessor<T>`.
+
+For one-shot use, `accessWithJsonSelector` combines both steps.
+
+### `accessWithJsonSelector`
+
+```ts
+function accessWithJsonSelector(
+  selector: JsonSelector,
+  context: unknown,
+  rootContext?: unknown, // defaults to context
+  options?: Partial<AccessorOptions>,
+): Accessor<unknown>;
+```
+
+Compiles and binds a selector in one step. Returns a bound `Accessor`.
+
+**`AccessorOptions`**
+
+| Field                   | Type                           | Default            | Description                                                |
+| ----------------------- | ------------------------------ | ------------------ | ---------------------------------------------------------- |
+| `functionProvider`      | `FunctionProvider`             | Built-in functions | Function lookup table for evaluation                       |
+| `bindings`              | `ReadonlyMap<string, unknown>` | —                  | Lexical-scope variable bindings (name without `$` → value) |
+| `legacyNullPropagation` | `boolean`                      | `false`            | Propagate `null` through multi-select expressions          |
+
+### `makeJsonSelectorAccessor`
+
+```ts
+function makeJsonSelectorAccessor(
+  selector: JsonSelector,
+  options?: Partial<AccessorOptions>,
+): UnboundAccessor;
+```
+
+Compiles a selector AST into a reusable `UnboundAccessor`.
+
+**`UnboundAccessor`**
+
+```ts
+interface UnboundAccessor {
+  readonly selector: JsonSelector;
+  isValidContext(context: unknown, rootContext?: unknown): boolean;
+  get(context: unknown, rootContext?: unknown): unknown;
+  set(value: unknown, context: unknown, rootContext?: unknown): void;
+  delete(context: unknown, rootContext?: unknown): void;
+}
+```
+
+- `isValidContext` — returns `true` if the selector can meaningfully operate on the given context (e.g., field access requires an object).
+- `set` and `delete` are no-ops for read-only expressions (comparisons, logical operators, `!`).
+- For projections, filters, and slices, `set` applies the value to each matching element, and `delete` removes matching elements while preserving non-matching ones.
+
+### `bindJsonSelectorAccessor`
+
+```ts
+function bindJsonSelectorAccessor(
+  unbound: UnboundAccessor,
+  context: unknown,
+  rootContext?: unknown, // defaults to context
+): Accessor<unknown>;
+```
+
+Binds an unbound accessor to a specific context.
+
+**`Accessor<T>`**
+
+```ts
+interface Accessor<T> {
+  readonly selector: JsonSelector;
+  readonly valid: boolean; // result of isValidContext
+  readonly path: string; // formatted selector string
+  get(): T;
+  set(value: T): void;
+  delete(): void;
+}
+```
+
+### `getWithJsonSelector`
+
+```ts
+function getWithJsonSelector(
+  selector: JsonSelector,
+  context: unknown,
+  options?: Partial<AccessorOptions>,
+): unknown;
+```
+
+Read-only convenience wrapper. Equivalent to `accessWithJsonSelector(selector, context, context, options).get()`.
+
+### `setWithJsonSelector`
+
+```ts
+function setWithJsonSelector(
+  selector: JsonSelector,
+  context: unknown,
+  value: unknown,
+  options?: Partial<AccessorOptions>,
+): unknown;
+```
+
+Sets the value at the selector path and returns the previous value.
+
+---
+
+## Visitor
+
+### `visitJsonSelector`
+
+```ts
+function visitJsonSelector<R, C>(
+  selector: JsonSelector,
+  visitor: Visitor<R, C>,
+  context: C,
+): R;
+```
+
+Dispatches to the appropriate method on `visitor` based on the node's `type` discriminator. This is the recommended way to traverse the AST rather than writing manual `switch` statements.
+
+### Visitor Interface
+
+```ts
+interface Visitor<R, C> {
+  current(node: JsonSelectorCurrent, context: C): R;
+  root(node: JsonSelectorRoot, context: C): R;
+  literal(node: JsonSelectorLiteral, context: C): R;
+  identifier(node: JsonSelectorIdentifier, context: C): R;
+  fieldAccess(node: JsonSelectorFieldAccess, context: C): R;
+  indexAccess(node: JsonSelectorIndexAccess, context: C): R;
+  idAccess(node: JsonSelectorIdAccess, context: C): R;
+  project(node: JsonSelectorProject, context: C): R;
+  filter(node: JsonSelectorFilter, context: C): R;
+  slice(node: JsonSelectorSlice, context: C): R;
+  flatten(node: JsonSelectorFlatten, context: C): R;
+  not(node: JsonSelectorNot, context: C): R;
+  compare(node: JsonSelectorCompare, context: C): R;
+  arithmetic(node: JsonSelectorArithmetic, context: C): R;
+  unaryArithmetic(node: JsonSelectorUnaryArithmetic, context: C): R;
+  and(node: JsonSelectorAnd, context: C): R;
+  or(node: JsonSelectorOr, context: C): R;
+  ternary(node: JsonSelectorTernary, context: C): R;
+  pipe(node: JsonSelectorPipe, context: C): R;
+  functionCall(node: JsonSelectorFunctionCall, context: C): R;
+  expressionRef(node: JsonSelectorExpressionRef, context: C): R;
+  variableRef(node: JsonSelectorVariableRef, context: C): R;
+  let(node: JsonSelectorLet, context: C): R;
+  multiSelectList(node: JsonSelectorMultiSelectList, context: C): R;
+  multiSelectHash(node: JsonSelectorMultiSelectHash, context: C): R;
+  objectProject(node: JsonSelectorObjectProject, context: C): R;
+}
+```
+
+`R` is the return type of each visitor method. `C` is a context value threaded through all calls.
+
+---
+
+## Function System
+
+### `FunctionRegistry`
+
+```ts
+class FunctionRegistry implements FunctionProvider {
+  constructor(baseProvider?: FunctionProvider | null);
+  register(def: FunctionDefinition): void;
+  unregister(name: string): boolean;
+}
+```
+
+A mutable registry that layers custom functions on top of a base provider. By default, the base provider is the built-in function set. Pass `null` to start with no built-in functions.
+
+Custom functions override built-in functions of the same name. `unregister` only removes custom functions, not base functions.
+
+Pass a `FunctionRegistry` as the `functionProvider` in `EvaluationContext` or `AccessorOptions`.
+
+**Example: registering a custom function**
+
+```ts
+import {
+  parseJsonSelector,
+  evaluateJsonSelector,
+  FunctionRegistry,
+  arg,
+  NUMBER_TYPE,
+} from "@loancrate/json-selector";
+
+const registry = new FunctionRegistry();
+registry.register({
+  name: "double",
+  signatures: [[arg("value", NUMBER_TYPE)]],
+  handler: ({ args }) => (args[0] as number) * 2,
+});
+
+const selector = parseJsonSelector("double(age)");
+const result = evaluateJsonSelector(
+  selector,
+  { age: 21 },
+  {
+    functionProvider: registry,
+  },
+);
+// result === 42
+```
+
+### `getBuiltinFunctionProvider`
+
+```ts
+function getBuiltinFunctionProvider(): FunctionProvider;
+```
+
+Returns a singleton `FunctionProvider` (a `ReadonlyMap<string, FunctionDefinition>`) containing all built-in functions. Used as the default when no custom function provider is specified.
+
+### `FunctionDefinition`
+
+```ts
+interface FunctionDefinition {
+  name: string;
+  signatures: NonEmptyArray<ArgumentSignature[]>;
+  handler: FunctionHandler;
+}
+```
+
+- `signatures` — one or more overloaded parameter lists. Arguments are validated against each signature in order until one matches.
+- `handler` — receives `FunctionCallBindings` with pre-validated `args`, `context`, `evaluate`, and evaluation context fields.
+
+### Type Constants
+
+Pre-defined type descriptors for function signatures:
+
+| Constant            | Matches                         |
+| ------------------- | ------------------------------- |
+| `ANY_TYPE`          | Any value                       |
+| `BOOLEAN_TYPE`      | `true` or `false`               |
+| `NUMBER_TYPE`       | Numbers                         |
+| `STRING_TYPE`       | Strings                         |
+| `OBJECT_TYPE`       | Plain objects                   |
+| `NULL_TYPE`         | `null`                          |
+| `EXPREF_TYPE`       | Expression references (`&expr`) |
+| `ANY_ARRAY_TYPE`    | Arrays of any element type      |
+| `NUMBER_ARRAY_TYPE` | Arrays of numbers               |
+| `STRING_ARRAY_TYPE` | Arrays of strings               |
+
+### Type Utilities
+
+```ts
+function arrayOf(elementType: ConcreteType): ArrayType;
+function unionOf(
+  types: [ConcreteType, ConcreteType, ...ConcreteType[]],
+): UnionType;
+function matchesType(value: unknown, type: DataType): boolean;
+function getDataType(value: unknown): ConcreteType;
+function getDataTypeKind(value: unknown): ConcreteTypeKind;
+function formatType(type: DataType): string;
+```
+
+- `arrayOf` — creates an array type with a specific element type.
+- `unionOf` — creates a union type from two or more concrete types.
+- `matchesType` — tests if a runtime value conforms to a type descriptor.
+- `getDataType` / `getDataTypeKind` — introspect the type of a runtime value.
+- `formatType` — formats a type descriptor as a human-readable string for error messages.
+
+### Signature Helpers
+
+```ts
+function arg(name: string, type: DataType): ArgumentSignature;
+function optArg(name: string, type: DataType): ArgumentSignature;
+function varArg(name: string, type: DataType): ArgumentSignature;
+```
+
+- `arg` — required parameter.
+- `optArg` — optional parameter (must appear after all required parameters).
+- `varArg` — variadic parameter accepting one or more values (must be last).
+
+---
+
+## Error Hierarchy
+
+All errors thrown by the library extend `JsonSelectorError`. Parse-time and runtime errors form two separate branches.
+
+```
+JsonSelectorError
+├── JsonSelectorSyntaxError
+│   ├── UnexpectedCharacterError
+│   ├── UnterminatedTokenError
+│   ├── InvalidTokenError
+│   ├── UnexpectedTokenError
+│   └── UnexpectedEndOfInputError
+└── JsonSelectorRuntimeError
+    ├── JsonSelectorTypeError
+    │   ├── NotANumberError
+    │   └── DivideByZeroError
+    ├── UndefinedVariableError
+    └── FunctionError
+        ├── UnknownFunctionError
+        ├── InvalidArityError
+        └── InvalidArgumentError
+            ├── InvalidArgumentTypeError
+            └── InvalidArgumentValueError
+```
+
+### Syntax Errors
+
+All syntax errors extend `JsonSelectorSyntaxError` and include:
+
+| Field        | Type     | Description                                 |
+| ------------ | -------- | ------------------------------------------- |
+| `expression` | `string` | The expression being parsed                 |
+| `offset`     | `number` | Character position where the error occurred |
+
+**Subclasses and their additional fields:**
+
+| Error                       | Additional Fields                                        |
+| --------------------------- | -------------------------------------------------------- |
+| `UnexpectedCharacterError`  | `character: string`                                      |
+| `UnterminatedTokenError`    | `tokenKind: string`, `expectedDelimiter: string`         |
+| `InvalidTokenError`         | `tokenKind: string`, `detail: string`                    |
+| `UnexpectedTokenError`      | `token: string`, `expected?: string`, `context?: string` |
+| `UnexpectedEndOfInputError` | `expected?: string`                                      |
+
+### Runtime Errors
+
+All runtime errors extend `JsonSelectorRuntimeError`.
+
+| Error                       | Fields                                  | Thrown When                                                                         |
+| --------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------- |
+| `NotANumberError`           | `operator`, `operandRole`, `actualType` | Arithmetic on non-numeric operand                                                   |
+| `DivideByZeroError`         | `operator`, `divisor`                   | Division or integer division by zero                                                |
+| `UndefinedVariableError`    | `variableName`                          | Referencing an unbound `$variable`                                                  |
+| `UnknownFunctionError`      | `functionName`                          | Calling a function that doesn't exist                                               |
+| `InvalidArityError`         | `functionName`                          | Wrong number of arguments                                                           |
+| `InvalidArgumentTypeError`  | `functionName`, `argumentName`          | Argument has wrong type                                                             |
+| `InvalidArgumentValueError` | `functionName`, `argumentName`          | Argument type is valid but value is not (e.g., negative integer, non-integer float) |
+
+---
+
+## AST Reference
+
+`JsonSelector` is a discriminated union of 26 node types. Use `node.type` for pattern matching, or [`visitJsonSelector`](#visitjsonselector) for type-safe traversal.
+
+`JsonSelectorNodeType` is the string literal union of all `type` discriminators.
+
+| `type`              | Interface                     | Key Fields                                     |
+| ------------------- | ----------------------------- | ---------------------------------------------- |
+| `"current"`         | `JsonSelectorCurrent`         | `explicit?: boolean`                           |
+| `"root"`            | `JsonSelectorRoot`            | —                                              |
+| `"literal"`         | `JsonSelectorLiteral`         | `value: JsonValue`, `backtickSyntax?: boolean` |
+| `"identifier"`      | `JsonSelectorIdentifier`      | `id: string`                                   |
+| `"fieldAccess"`     | `JsonSelectorFieldAccess`     | `expression`, `field: string`                  |
+| `"indexAccess"`     | `JsonSelectorIndexAccess`     | `expression`, `index: number`                  |
+| `"idAccess"`        | `JsonSelectorIdAccess`        | `expression`, `id: string`                     |
+| `"project"`         | `JsonSelectorProject`         | `expression`, `projection?: JsonSelector`      |
+| `"objectProject"`   | `JsonSelectorObjectProject`   | `expression`, `projection?: JsonSelector`      |
+| `"filter"`          | `JsonSelectorFilter`          | `expression`, `condition: JsonSelector`        |
+| `"slice"`           | `JsonSelectorSlice`           | `expression`, `start?`, `end?`, `step?`        |
+| `"flatten"`         | `JsonSelectorFlatten`         | `expression`                                   |
+| `"not"`             | `JsonSelectorNot`             | `expression`                                   |
+| `"compare"`         | `JsonSelectorCompare`         | `operator`, `lhs`, `rhs`                       |
+| `"arithmetic"`      | `JsonSelectorArithmetic`      | `operator`, `lhs`, `rhs`                       |
+| `"unaryArithmetic"` | `JsonSelectorUnaryArithmetic` | `operator`, `expression`                       |
+| `"and"`             | `JsonSelectorAnd`             | `lhs`, `rhs`                                   |
+| `"or"`              | `JsonSelectorOr`              | `lhs`, `rhs`                                   |
+| `"ternary"`         | `JsonSelectorTernary`         | `condition`, `consequent`, `alternate`         |
+| `"pipe"`            | `JsonSelectorPipe`            | `lhs`, `rhs`, `dotSyntax?: boolean`            |
+| `"functionCall"`    | `JsonSelectorFunctionCall`    | `name: string`, `args: JsonSelector[]`         |
+| `"expressionRef"`   | `JsonSelectorExpressionRef`   | `expression`                                   |
+| `"variableRef"`     | `JsonSelectorVariableRef`     | `name: string`                                 |
+| `"let"`             | `JsonSelectorLet`             | `bindings: {name, value}[]`, `expression`      |
+| `"multiSelectList"` | `JsonSelectorMultiSelectList` | `expressions: JsonSelector[]`                  |
+| `"multiSelectHash"` | `JsonSelectorMultiSelectHash` | `entries: {key, value}[]`                      |
+
+All `expression`, `lhs`, `rhs`, `condition`, `consequent`, and `alternate` fields are of type `JsonSelector`. For complete type definitions, see `src/ast.ts` or use your editor's TypeScript support.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,94 @@
+# Benchmark CLI
+
+The benchmark tool measures parsing performance and compares results across JMESPath implementations.
+
+## Quick Start
+
+```bash
+npm run benchmark
+```
+
+Runs the full benchmark suite using json-selector and prints a formatted results table.
+
+## Options
+
+| Flag           | Type      | Default         | Description                                                                 |
+| -------------- | --------- | --------------- | --------------------------------------------------------------------------- |
+| `--library`    | `string`  | `json-selector` | Library to benchmark: `json-selector`, `jmespath`, or `typescript-jmespath` |
+| `--iterations` | `number`  | `10000`         | Number of measured iterations per test case                                 |
+| `--warmup`     | `number`  | `1000`          | Warmup iterations before measurement (JIT warm-up)                          |
+| `--runs`       | `number`  | `3`             | Independent measurement runs; the best run is kept                          |
+| `--compact`    | `boolean` | `false`         | Compact output: truncate long expressions, omit StdDev/Min columns          |
+| `--output`     | `string`  | —               | Save results to a JSON file                                                 |
+| `--json`       | `boolean` | `false`         | Output results as JSON to stdout (no tables)                                |
+| `--show`       | `string`  | —               | Load and display a saved JSON results file                                  |
+| `--compare`    | `boolean` | `false`         | Compare two saved result files (requires two positional arguments)          |
+| `--threshold`  | `number`  | `10`            | Regression threshold percentage for `--compare`                             |
+
+## Library Comparison
+
+Three JMESPath implementations can be benchmarked:
+
+| Library               | Package                        | Notes                                                                                |
+| --------------------- | ------------------------------ | ------------------------------------------------------------------------------------ |
+| `json-selector`       | `@loancrate/json-selector`     | Full feature set including extensions                                                |
+| `jmespath`            | `jmespath`                     | Original jmespath.js; excludes root node (`$`), ID access (`['id']`), and arithmetic |
+| `typescript-jmespath` | `@jmespath-community/jmespath` | Community fork; excludes ID access (`['id']`)                                        |
+
+Test cases incompatible with a library are automatically skipped.
+
+```bash
+npm run benchmark -- --library jmespath
+npm run benchmark -- --library typescript-jmespath
+```
+
+## Saving and Comparing Results
+
+Save a baseline:
+
+```bash
+npm run benchmark -- --output baseline.json
+```
+
+Save a current run and compare:
+
+```bash
+npm run benchmark -- --output current.json
+npm run benchmark -- --compare baseline.json current.json
+```
+
+The comparison table shows each test case with baseline time, current time, percentage change, and a status flag (`FASTER`, `SLOWER`, or blank for within threshold).
+
+Display saved results without re-running:
+
+```bash
+npm run benchmark -- --show baseline.json
+```
+
+## Tuning
+
+For more stable results, increase iterations and runs:
+
+```bash
+npm run benchmark -- --iterations 50000 --runs 5
+```
+
+For quick spot-checks, use lower values and compact output:
+
+```bash
+npm run benchmark -- --iterations 1000 --runs 1 --compact
+```
+
+## Output Metrics
+
+Each test case reports:
+
+| Metric  | Description                        |
+| ------- | ---------------------------------- |
+| Avg     | Mean time per parse (microseconds) |
+| StdDev  | Standard deviation                 |
+| Min     | Fastest single parse               |
+| p99     | 99th percentile                    |
+| Ops/sec | Operations per second              |
+
+A summary section follows the table with overall percentile distribution, the slowest test cases, and scaling characteristics.

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1,0 +1,525 @@
+# Function Reference
+
+All built-in functions available in LoanCrate JSON Selector expressions. See the [API Reference](api.md#function-system) for registering custom functions.
+
+**Error handling:** All functions validate argument count and types. Calling with the wrong number of arguments throws `InvalidArityError`. Passing an argument of the wrong type throws `InvalidArgumentTypeError`. Calling an undefined function throws `UnknownFunctionError`. Additional function-specific errors are noted in the detailed sections below.
+
+## Summary
+
+### Type Functions
+
+| Function                  | Signature                         | Description                                   |
+| ------------------------- | --------------------------------- | --------------------------------------------- |
+| [`to_array`](#to_array)   | `to_array(any) → array`           | Wraps a non-array value in an array           |
+| [`to_number`](#to_number) | `to_number(any) → number \| null` | Converts a value to a number                  |
+| [`to_string`](#to_string) | `to_string(any) → string`         | Converts a value to its string representation |
+| [`type`](#type)           | `type(any) → string`              | Returns the type name of a value              |
+
+### String Functions
+
+| Function                      | Signature                                                       | Description                                             |
+| ----------------------------- | --------------------------------------------------------------- | ------------------------------------------------------- |
+| [`contains`](#contains)       | `contains(string \| array, any) → boolean`                      | Tests if a value contains a search target               |
+| [`ends_with`](#ends_with)     | `ends_with(string, string) → boolean`                           | Tests if a string ends with a suffix                    |
+| [`find_first`](#find_first)   | `find_first(string, string, number?, number?) → number \| null` | Finds the first occurrence of a substring               |
+| [`find_last`](#find_last)     | `find_last(string, string, number?, number?) → number \| null`  | Finds the last occurrence of a substring                |
+| [`join`](#join)               | `join(string, string[]) → string`                               | Joins array elements with a delimiter                   |
+| [`length`](#length)           | `length(string \| array \| object) → number`                    | Returns the length of a value                           |
+| [`lower`](#lower)             | `lower(string) → string`                                        | Converts a string to lowercase                          |
+| [`pad_left`](#pad_left)       | `pad_left(string, number, string?) → string`                    | Pads a string on the left                               |
+| [`pad_right`](#pad_right)     | `pad_right(string, number, string?) → string`                   | Pads a string on the right                              |
+| [`replace`](#replace)         | `replace(string, string, string, number?) → string`             | Replaces occurrences of a substring                     |
+| [`reverse`](#reverse)         | `reverse(string \| array) → string \| array`                    | Reverses a string or array                              |
+| [`split`](#split)             | `split(string, string, number?) → string[]`                     | Splits a string by a delimiter                          |
+| [`starts_with`](#starts_with) | `starts_with(string, string) → boolean`                         | Tests if a string starts with a prefix                  |
+| [`trim`](#trim)               | `trim(string, string?) → string`                                | Trims whitespace or specified characters from both ends |
+| [`trim_left`](#trim_left)     | `trim_left(string, string?) → string`                           | Trims from the left end                                 |
+| [`trim_right`](#trim_right)   | `trim_right(string, string?) → string`                          | Trims from the right end                                |
+| [`upper`](#upper)             | `upper(string) → string`                                        | Converts a string to uppercase                          |
+
+### Math Functions
+
+| Function          | Signature                                              | Description                    |
+| ----------------- | ------------------------------------------------------ | ------------------------------ |
+| [`abs`](#abs)     | `abs(number) → number`                                 | Absolute value                 |
+| [`avg`](#avg)     | `avg(number[]) → number \| null`                       | Average of array elements      |
+| [`ceil`](#ceil)   | `ceil(number) → number`                                | Rounds up to nearest integer   |
+| [`floor`](#floor) | `floor(number) → number`                               | Rounds down to nearest integer |
+| [`max`](#max)     | `max(number[] \| string[]) → number \| string \| null` | Maximum value                  |
+| [`min`](#min)     | `min(number[] \| string[]) → number \| string \| null` | Minimum value                  |
+| [`sum`](#sum)     | `sum(number[]) → number`                               | Sum of array elements          |
+
+### Array and Object Functions
+
+| Function                    | Signature                            | Description                           |
+| --------------------------- | ------------------------------------ | ------------------------------------- |
+| [`from_items`](#from_items) | `from_items(array) → object`         | Creates an object from pairs          |
+| [`group_by`](#group_by)     | `group_by(array, &expr) → object`    | Groups elements by a key              |
+| [`items`](#items)           | `items(object) → array`              | Returns `[key, value]` pairs          |
+| [`keys`](#keys)             | `keys(object) → string[]`            | Returns object keys                   |
+| [`map`](#map)               | `map(&expr, array) → array`          | Applies an expression to each element |
+| [`max_by`](#max_by)         | `max_by(array, &expr) → any`         | Element with maximum key              |
+| [`merge`](#merge)           | `merge(...object) → object`          | Merges objects                        |
+| [`min_by`](#min_by)         | `min_by(array, &expr) → any`         | Element with minimum key              |
+| [`not_null`](#not_null)     | `not_null(...any) → any`             | First non-null argument               |
+| [`sort`](#sort)             | `sort(number[] \| string[]) → array` | Sorts an array                        |
+| [`sort_by`](#sort_by)       | `sort_by(array, &expr) → array`      | Sorts by an expression key            |
+| [`values`](#values)         | `values(object) → array`             | Returns object values                 |
+| [`zip`](#zip)               | `zip(...array) → array`              | Transposes arrays into tuples         |
+
+---
+
+## Type Functions
+
+### `to_array`
+
+```
+to_array(value: any) → array
+```
+
+If `value` is already an array, returns it unchanged. Otherwise, wraps it in a single-element array: `[value]`.
+
+### `to_number`
+
+```
+to_number(value: any) → number | null
+```
+
+Converts `value` to a number.
+
+- **Numbers** pass through unchanged.
+- **Strings** conforming to JSON number syntax are parsed. Empty and whitespace-only strings return `null`. Non-numeric strings return `null`.
+- **All other types** return `null`.
+
+### `to_string`
+
+```
+to_string(value: any) → string
+```
+
+Converts `value` to a string. Strings pass through unchanged. All other types are JSON-serialized (e.g., `to_string(`42`)` returns `"42"`, `to_string(`true`)` returns `"true"`).
+
+### `type`
+
+```
+type(value: any) → string
+```
+
+Returns the type of `value` as one of: `"array"`, `"boolean"`, `"null"`, `"number"`, `"object"`, `"string"`.
+
+---
+
+## String Functions
+
+### `contains`
+
+```
+contains(subject: string | array, search: any) → boolean
+```
+
+- **String subject**: returns `true` if `subject` contains `search` as a substring. Both must be strings.
+- **Array subject**: returns `true` if any element of `subject` is equal to `search` (reference equality via `includes`).
+
+### `ends_with`
+
+```
+ends_with(subject: string, suffix: string) → boolean
+```
+
+Returns `true` if `subject` ends with `suffix`.
+
+### `find_first`
+
+```
+find_first(subject: string, search: string, start?: number, end?: number) → number | null
+```
+
+Returns the index of the first occurrence of `search` within `subject[start:end]`, or `null` if not found.
+
+- `search` of `""` (empty string) always returns `null`.
+- `start` defaults to `0`. Negative values count from the end.
+- `end` defaults to `subject.length`. Negative values count from the end.
+- The returned index is relative to the beginning of `subject`, not to `start`.
+
+Throws `InvalidArgumentValueError` if `start` or `end` is not an integer.
+
+Note: indices are based on UTF-16 code units (JavaScript string positions), not Unicode code points.
+
+### `find_last`
+
+```
+find_last(subject: string, search: string, start?: number, end?: number) → number | null
+```
+
+Like [`find_first`](#find_first), but returns the index of the _last_ occurrence within the range.
+
+Throws `InvalidArgumentValueError` if `start` or `end` is not an integer.
+
+### `join`
+
+```
+join(glue: string, list: string[]) → string
+```
+
+Joins all elements of `list` into a single string, separated by `glue`.
+
+Note the parameter order: delimiter first, then array. This matches the JMESPath specification.
+
+### `length`
+
+```
+length(subject: string | array | object) → number
+```
+
+Returns the length of the subject.
+
+- **Strings**: counts Unicode code points (not UTF-16 code units). A surrogate pair (e.g., an emoji) counts as one.
+- **Arrays**: returns `array.length`.
+- **Objects**: returns the number of keys.
+
+### `lower`
+
+```
+lower(subject: string) → string
+```
+
+Converts `subject` to lowercase using the default locale-independent transformation.
+
+### `pad_left`
+
+```
+pad_left(subject: string, width: number, pad?: string) → string
+```
+
+Pads `subject` on the left to reach `width` characters.
+
+- `pad` defaults to a space character.
+- If `subject` is already at least `width` characters, it is returned unchanged.
+
+Throws `InvalidArgumentValueError` if `width` is not a non-negative integer, or if `pad` is not exactly one character long.
+
+### `pad_right`
+
+```
+pad_right(subject: string, width: number, pad?: string) → string
+```
+
+Like [`pad_left`](#pad_left), but pads on the right.
+
+Throws `InvalidArgumentValueError` if `width` is not a non-negative integer, or if `pad` is not exactly one character long.
+
+### `replace`
+
+```
+replace(subject: string, old: string, new: string, count?: number) → string
+```
+
+Replaces occurrences of `old` with `new` in `subject`.
+
+- Without `count`: replaces all occurrences.
+- With `count`: replaces at most `count` occurrences, left to right.
+- `count` of `0` returns the original string unchanged.
+
+Throws `InvalidArgumentValueError` if `count` is not a non-negative integer.
+
+### `reverse`
+
+```
+reverse(subject: string | array) → string | array
+```
+
+Returns a reversed copy.
+
+- **Strings**: splits into Unicode code points, reverses, and rejoins. Handles surrogate pairs correctly.
+- **Arrays**: returns a new array in reverse order (does not mutate the original).
+
+### `split`
+
+```
+split(subject: string, delimiter: string, count?: number) → string[]
+```
+
+Splits `subject` by `delimiter`.
+
+The optional `count` parameter limits the number of _splits_ performed (not the number of results). The remainder of the string after the last split becomes the final element.
+
+- `split('a,b,c', ',')` returns `["a", "b", "c"]`
+- `split('a,b,c', ',', 1)` returns `["a", "b,c"]`
+- `split('a,b,c', ',', 0)` returns `["a,b,c"]`
+
+Throws `InvalidArgumentValueError` if `count` is not a non-negative integer.
+
+### `starts_with`
+
+```
+starts_with(subject: string, prefix: string) → boolean
+```
+
+Returns `true` if `subject` starts with `prefix`.
+
+### `trim`
+
+```
+trim(subject: string, chars?: string) → string
+```
+
+Removes characters from both ends of `subject`.
+
+- Without `chars`: trims Unicode whitespace (including U+0085 NEXT LINE).
+- With `chars`: trims any characters present in the `chars` string.
+
+### `trim_left`
+
+```
+trim_left(subject: string, chars?: string) → string
+```
+
+Like [`trim`](#trim), but only from the left (start) of the string.
+
+### `trim_right`
+
+```
+trim_right(subject: string, chars?: string) → string
+```
+
+Like [`trim`](#trim), but only from the right (end) of the string.
+
+### `upper`
+
+```
+upper(subject: string) → string
+```
+
+Converts `subject` to uppercase using the default locale-independent transformation.
+
+---
+
+## Math Functions
+
+### `abs`
+
+```
+abs(value: number) → number
+```
+
+Returns the absolute value.
+
+### `avg`
+
+```
+avg(list: number[]) → number | null
+```
+
+Returns the arithmetic mean. Returns `null` for empty arrays. Divides by `list.length` (the total number of elements).
+
+### `ceil`
+
+```
+ceil(value: number) → number
+```
+
+Returns the smallest integer greater than or equal to `value`.
+
+### `floor`
+
+```
+floor(value: number) → number
+```
+
+Returns the largest integer less than or equal to `value`.
+
+### `max`
+
+```
+max(list: number[] | string[]) → number | string | null
+```
+
+Returns the maximum value from a homogeneous array of numbers or strings. Returns `null` for empty arrays.
+
+String comparison uses Unicode code point ordering.
+
+### `min`
+
+```
+min(list: number[] | string[]) → number | string | null
+```
+
+Returns the minimum value from a homogeneous array of numbers or strings. Returns `null` for empty arrays.
+
+String comparison uses Unicode code point ordering.
+
+### `sum`
+
+```
+sum(list: number[]) → number
+```
+
+Returns the sum of all numeric elements. Returns `0` for empty arrays.
+
+---
+
+## Array and Object Functions
+
+### `from_items`
+
+```
+from_items(list: array) → object
+```
+
+Creates an object from an array of `[key, value]` pairs. Each element must be a two-element array where the first element is a string.
+
+Throws `InvalidArgumentValueError` if any element is not a two-element array or its first element is not a string.
+
+```
+from_items([['a', 1], ['b', 2]])   # {"a": 1, "b": 2}
+```
+
+### `group_by`
+
+```
+group_by(list: array, expref: &expression) → object
+```
+
+Groups `list` elements by evaluating `expref` against each element.
+
+- The expression must evaluate to a string or `null` for each element.
+- Elements with `null` keys are excluded from the result.
+- Returns an object mapping string keys to arrays of matching elements.
+
+Throws `InvalidArgumentTypeError` if the expression evaluates to a non-string, non-null type for any element.
+
+```
+group_by(people, &department)   # {"Engineering": [...], "Sales": [...]}
+```
+
+### `items`
+
+```
+items(obj: object) → array
+```
+
+Returns an array of `[key, value]` pairs from the object (equivalent to `Object.entries()`).
+
+### `keys`
+
+```
+keys(obj: object) → string[]
+```
+
+Returns an array of the object's own enumerable property names.
+
+### `map`
+
+```
+map(expref: &expression, list: array) → array
+```
+
+Applies `expref` to each element of `list` and returns an array of results.
+
+Note the parameter order: expression reference first, then array. This matches the JMESPath specification.
+
+```
+map(&to_upper(@), names)        # uppercase each name
+map(&age, people)               # extract age from each person
+```
+
+### `max_by`
+
+```
+max_by(list: array, expref: &expression) → any
+```
+
+Returns the element from `list` with the maximum key value when `expref` is evaluated. Returns `null` for empty arrays.
+
+Throws `InvalidArgumentTypeError` if the expression evaluates to a type other than number or string.
+
+### `merge`
+
+```
+merge(...objects: object) → object
+```
+
+Merges one or more objects left to right. Later values override earlier ones for duplicate keys.
+
+```
+merge({a: 1}, {b: 2}, {a: 3})   # {a: 3, b: 2}
+```
+
+Requires at least one argument.
+
+### `min_by`
+
+```
+min_by(list: array, expref: &expression) → any
+```
+
+Returns the element from `list` with the minimum key value when `expref` is evaluated. Returns `null` for empty arrays.
+
+Throws `InvalidArgumentTypeError` if the expression evaluates to a type other than number or string.
+
+### `not_null`
+
+```
+not_null(...args: any) → any
+```
+
+Returns the first argument that is not `null` or `undefined`. Returns `null` if all arguments are null.
+
+```
+not_null(null, 'hello', null)    # 'hello'
+not_null(null, null)             # null
+```
+
+Requires at least one argument.
+
+### `sort`
+
+```
+sort(list: number[] | string[]) → array
+```
+
+Returns a new sorted array. The array must be homogeneous (all numbers or all strings).
+
+- **Numbers**: sorted ascending numerically.
+- **Strings**: sorted by Unicode code point comparison (not locale-sensitive).
+- Empty arrays return `[]`.
+
+### `sort_by`
+
+```
+sort_by(list: array, expref: &expression) → array
+```
+
+Sorts `list` by evaluating `expref` against each element. The expression must evaluate to a consistent type across all elements — either all numbers or all strings (nulls are not allowed).
+
+Uses a Schwartzian transform: keys are evaluated once per element, not during comparison.
+
+Throws `InvalidArgumentTypeError` if the expression evaluates to a non-number/non-string type, or if key types are inconsistent across elements.
+
+```
+sort_by(people, &age)           # sort by numeric age
+sort_by(items, &name)           # sort by string name
+```
+
+### `values`
+
+```
+values(obj: object) → array
+```
+
+Returns an array of the object's own enumerable property values.
+
+### `zip`
+
+```
+zip(...lists: array) → array
+```
+
+Transposes multiple arrays into an array of tuples. Uses the minimum length among all input arrays.
+
+```
+zip([1, 2], ['a', 'b'])         # [[1, 'a'], [2, 'b']]
+zip([1, 2, 3], ['a', 'b'])      # [[1, 'a'], [2, 'b']]
+```
+
+Returns `[]` if no arguments are provided.

--- a/docs/language.md
+++ b/docs/language.md
@@ -1,0 +1,508 @@
+# Expression Language Reference
+
+LoanCrate JSON Selectors implement [JMESPath](https://jmespath.org) and [JMESPath Community Edition](https://jmespath.site/main/) with two extensions: [ID-based access](#id-based-access-extension) and [bare numeric literals](#bare-numeric-literals-extension).
+
+## Summary
+
+Precedence is numbered 1 (tightest) through 8 (loosest). Prefix and postfix operators are listed separately.
+
+### Operators and Expressions
+
+| #   | Group                           | Element                             | Syntax                               |
+| --- | ------------------------------- | ----------------------------------- | ------------------------------------ |
+| 1   | [Arithmetic](#arithmetic)       | [Multiply](#multiplication)         | `a * b`, `a × b`                     |
+| 1   | [Arithmetic](#arithmetic)       | [Divide](#division)                 | `a / b`, `a ÷ b`                     |
+| 1   | [Arithmetic](#arithmetic)       | [Integer divide](#integer-division) | `a // b`                             |
+| 1   | [Arithmetic](#arithmetic)       | [Modulo](#modulo)                   | `a % b`                              |
+| 2   | [Arithmetic](#arithmetic)       | [Add](#addition)                    | `a + b`                              |
+| 2   | [Arithmetic](#arithmetic)       | [Subtract](#subtraction)            | `a - b`, `a − b`                     |
+| 3   | [Comparison](#comparison)       | [Equality](#equality)               | `a == b`, `a != b`                   |
+| 3   | [Comparison](#comparison)       | [Ordering](#ordering)               | `a < b`, `a <= b`, `a > b`, `a >= b` |
+| 4   | [Logical](#logical-operators)   | [AND](#logical-and)                 | `a && b`                             |
+| 5   | [Logical](#logical-operators)   | [OR](#logical-or)                   | `a \|\| b`                           |
+| 6   | [Control](#control-flow)        | [Ternary](#ternary)                 | `a ? b : c`                          |
+| 7   | [Control](#control-flow)        | [Pipe](#pipe)                       | `a \| b`                             |
+| 8   | [Variables](#variables-and-let) | [Let](#let-expressions)             | `let $x = e in body`                 |
+
+**Prefix operators** apply to the expression immediately to their right:
+
+| Group                         | Element                               | Syntax           | Binding                                   |
+| ----------------------------- | ------------------------------------- | ---------------- | ----------------------------------------- |
+| [Logical](#logical-operators) | [Logical NOT](#logical-not)           | `!expr`          | Immediate operand only: `!a.b` = `(!a).b` |
+| [Arithmetic](#arithmetic)     | [Unary plus/minus](#unary-arithmetic) | `+expr`, `-expr` | Through access: `-a.b` = `-(a.b)`         |
+
+**Postfix / access operators** chain left-to-right and bind tighter than all binary operators:
+
+| Group             | Element                                 | Syntax                |
+| ----------------- | --------------------------------------- | --------------------- |
+| [Access](#access) | [Identifier](#identifier)               | `name`                |
+| [Access](#access) | [Field access](#field-access)           | `expr.name`           |
+| [Access](#access) | [Index access](#index-access)           | `expr[0]`, `expr[-1]` |
+| [Access](#access) | [ID access](#id-based-access-extension) | `expr['id']`          |
+
+**Other expressions** (no precedence interaction):
+
+| Group                         | Element                                         | Syntax                                     |
+| ----------------------------- | ----------------------------------------------- | ------------------------------------------ |
+| [Context](#context)           | [Current node](#current-node)                   | `@`                                        |
+| [Context](#context)           | [Root document](#root-document)                 | `$`                                        |
+| [Literals](#literals)         | [JSON literal](#json-literals)                  | `` `42` ``, `` `"text"` ``, `` `[1, 2]` `` |
+| [Literals](#literals)         | [Raw string](#raw-strings)                      | `'text'`                                   |
+| [Literals](#literals)         | [Quoted string](#quoted-strings)                | `"text"`                                   |
+| [Literals](#literals)         | [Bare number](#bare-numeric-literals-extension) | `42`, `-3.14`                              |
+| [Literals](#literals)         | [Keywords](#keyword-literals)                   | `true`, `false`, `null`                    |
+| [Multi-select](#multi-select) | [List](#multi-select-list)                      | `[expr, expr]`                             |
+| [Multi-select](#multi-select) | [Hash](#multi-select-hash)                      | `{key: expr, key: expr}`                   |
+| [Functions](#function-calls)  | [Function call](#function-calls)                | `name(arg, ...)`                           |
+| [Functions](#function-calls)  | [Expression ref](#expression-references)        | `&expr`                                    |
+
+### Projections
+
+Projections map an operation over a collection. They continue through access operators but terminate before pipe, ternary, logical, comparison, and arithmetic operators.
+
+| Element                                 | Syntax                 | Description                  |
+| --------------------------------------- | ---------------------- | ---------------------------- |
+| [Array projection](#array-projection)   | `expr[*]`              | Map over array elements      |
+| [Object projection](#object-projection) | `expr.*`               | Map over object values       |
+| [Flatten](#flatten)                     | `expr[]`               | Flatten one level of nesting |
+| [Filter](#filter-projection)            | `expr[?condition]`     | Select matching elements     |
+| [Slice](#slice)                         | `expr[start:end:step]` | Select a range of elements   |
+
+---
+
+## Context
+
+### Current Node
+
+**Syntax**: `@`
+
+Refers to the current context value being evaluated. Usually implicit — a bare identifier `foo` is equivalent to `@.foo`. Explicit `@` is useful inside filter expressions and function arguments.
+
+```
+people[?@ == 'Alice']     # filter where the element itself equals 'Alice'
+people[*].name | [0]      # @ is implicit before people
+```
+
+### Root Document
+
+**Syntax**: `$`
+
+Refers to the top-level input document, regardless of the current evaluation context. Useful inside filters and let expressions to reference data outside the current scope.
+
+```
+machines[?state == $preferences.default_state]
+```
+
+---
+
+## Literals
+
+### JSON Literals
+
+**Syntax**: `` `value` ``
+
+Embeds a constant JSON value. The content between backticks must be valid JSON. Escape backticks with `\``.
+
+```
+`"hello"`         # string
+`42`              # number
+`[1, 2, 3]`      # array
+`{"a": 1}`        # object
+`true`            # boolean
+`null`            # null
+```
+
+Note: the backtick content must be valid JSON, so strings require inner quotes: `` `"hello"` ``, not `` `hello` ``.
+
+With `legacyLiterals` enabled, invalid JSON inside backticks falls back to a string (e.g., `` `foo` `` becomes `"foo"`).
+
+### Raw Strings
+
+**Syntax**: `'text'`
+
+A string literal where the content is taken verbatim. Escape single quotes with `\'`. By default, `\\` is also unescaped to `\`.
+
+```
+'hello world'
+'it\'s escaped'
+'backslash: \\'
+```
+
+With `legacyRawStringEscapes` enabled, only `\'` is unescaped; `\\` remains literal.
+
+### Quoted Strings
+
+**Syntax**: `"text"`
+
+An identifier or field name with JSON-style escape sequences (`\"`, `\\`, `\n`, `\t`, `\r`, `\b`, `\f`, `\uXXXX`). Additionally supports `\`` for backtick escaping.
+
+Quoted strings function as identifiers, not literal values. `"foo"` is equivalent to the identifier `foo` and accesses a field named `foo` on the current context.
+
+### Keyword Literals
+
+**Syntax**: `true`, `false`, `null`
+
+Boolean and null constant values, evaluated as JSON literals.
+
+### Bare Numeric Literals (Extension)
+
+**Syntax**: `42`, `-3.14`, `1e10`
+
+A JSON Selector extension that allows numeric literals without backtick delimiters in expression position. Supports integers, decimals, and scientific notation.
+
+```
+foo[?price > 0]       # 0 is a bare numeric literal
+a - 1                 # 1 is a bare numeric literal
+```
+
+The parser folds unary sign operators on bare numeric literals at parse time: `-42` becomes a single literal node with value `-42`.
+
+---
+
+## Access
+
+### Identifier
+
+**Syntax**: `name`
+
+Accesses a field on the current context object. Returns `null` if the field doesn't exist or the context isn't an object.
+
+Identifiers must start with a letter or underscore and contain letters, digits, and underscores. Use [quoted strings](#quoted-strings) for other field names.
+
+### Field Access
+
+**Syntax**: `expr.name`
+
+Accesses a named field on the result of `expr`. Equivalent to evaluating `expr` then looking up `name`.
+
+```
+foo.bar.baz           # nested field access
+```
+
+### Index Access
+
+**Syntax**: `expr[n]`
+
+Accesses an array element by index. Negative indices count from the end: `[-1]` is the last element, `[-2]` is second-to-last.
+
+Returns `null` if the index is out of bounds or the context isn't an array.
+
+```
+items[0]              # first element
+items[-1]             # last element
+```
+
+### ID-Based Access (Extension)
+
+**Syntax**: `expr['id']`
+
+A JSON Selector extension. Selects the first element from an array whose `id` property equals the given raw string. Formally equivalent to `expr[?id == 'id'] | [0]`.
+
+```
+users['alice']        # first element where id == 'alice'
+foo.bar['x'].value    # chain with other access
+```
+
+---
+
+## Projections
+
+Projections evaluate a sub-expression against each element of a collection. Null results are filtered out. Projections continue through subsequent access operators (`.field`, `[n]`, etc.) but terminate before pipe, logical, comparison, and arithmetic operators.
+
+### Array Projection
+
+**Syntax**: `expr[*]`
+
+Maps over all elements of an array. If the context is not an array, returns `null`.
+
+```
+people[*].name        # extract 'name' from each person
+items[*][0]           # first element of each sub-array
+```
+
+### Object Projection
+
+**Syntax**: `expr.*`
+
+Maps over all values of an object (keys are discarded). If the context is not an object, returns `null`.
+
+```
+machines.*.state      # extract 'state' from each machine value
+```
+
+### Flatten
+
+**Syntax**: `expr[]`
+
+Flattens one level of array nesting. Non-array elements and `null` values are discarded.
+
+```
+[[1, 2], [3, 4]]  | []         # [1, 2, 3, 4]
+[[1, 2], [3, 4]]  | [][]       # [1, 2, 3, 4] (already flat)
+[[[1, 2]], [[3]]]  | []        # [[1, 2], [3]]
+[[[1, 2]], [[3]]]  | [][]      # [1, 2, 3]
+```
+
+Flatten also creates a projection — subsequent access operators are applied to each element.
+
+### Filter Projection
+
+**Syntax**: `expr[?condition]`
+
+Selects array elements where `condition` is truthy. The condition is evaluated against each element with `@` as the current node.
+
+**Truthiness**: `null`, `false`, empty arrays `[]`, and empty objects `{}` are falsy. Everything else is truthy — including `0` and `""`.
+
+```
+people[?age >= 18]                # adults
+items[?state == 'active'].name    # names of active items
+people[?name]                     # people with a truthy name
+```
+
+### Slice
+
+**Syntax**: `expr[start:end:step]`
+
+Selects a range of array elements using Python-style slice semantics. All three parts are optional.
+
+- **start**: first index (inclusive). Default: `0` (or last index if step < 0).
+- **end**: stop index (exclusive). Default: array length (or before first if step < 0).
+- **step**: stride. Default: `1`. Cannot be `0` (throws an error).
+- Negative values for start/end count from the end of the array.
+- Negative step reverses iteration direction.
+
+```
+items[0:5]            # first 5 elements
+items[::2]            # every other element
+items[::-1]           # reversed array
+items[-3:]            # last 3 elements
+items[1:-1]           # all but first and last
+```
+
+---
+
+## Arithmetic
+
+All arithmetic operators require numeric operands. Non-numeric operands throw `NotANumberError`. Division by zero throws `DivideByZeroError`.
+
+Unicode operator variants are supported: `−` (U+2212) for subtraction/negation, `×` (U+00D7) for multiplication, `÷` (U+00F7) for division.
+
+### Addition
+
+**Syntax**: `a + b` &emsp; **Precedence**: 2
+
+Adds two numbers.
+
+### Subtraction
+
+**Syntax**: `a - b` or `a − b` &emsp; **Precedence**: 2
+
+Subtracts the right operand from the left.
+
+### Multiplication
+
+**Syntax**: `a * b` or `a × b` &emsp; **Precedence**: 1
+
+Multiplies two numbers. Note: `*` in bracket context (`[*]`) is an array projection, not multiplication.
+
+### Division
+
+**Syntax**: `a / b` or `a ÷ b` &emsp; **Precedence**: 1
+
+Divides the left operand by the right. Division by zero throws `DivideByZeroError`.
+
+### Integer Division
+
+**Syntax**: `a // b` &emsp; **Precedence**: 1
+
+Floor division — divides and rounds toward negative infinity. Division by zero throws `DivideByZeroError`.
+
+### Modulo
+
+**Syntax**: `a % b` &emsp; **Precedence**: 1
+
+Remainder after division.
+
+### Unary Arithmetic
+
+**Syntax**: `+expr`, `-expr`
+
+Unary plus (identity) or negation. When applied to a numeric literal, the sign is folded into the literal at parse time (`-42` becomes a single literal node).
+
+Unlike `!`, unary `+`/`-` extend through access operators: `-foo.bar` parses as `-(foo.bar)`, not `(-foo).bar`.
+
+---
+
+## Comparison
+
+All comparison operators have precedence 3. They are non-associative: `a < b < c` is a syntax error.
+
+### Equality
+
+**Syntax**: `a == b`, `a != b`
+
+Deep equality comparison using structural equality. Works on any types — two values of different types are never equal (except `null == null`).
+
+### Ordering
+
+**Syntax**: `a < b`, `a <= b`, `a > b`, `a >= b`
+
+Numeric ordering. Both operands must be numbers. If either operand is not a number, the result is `null` (not an error).
+
+---
+
+## Logical Operators
+
+### Logical NOT
+
+**Syntax**: `!expr`
+
+Returns `true` if `expr` is falsy, `false` otherwise. See [truthiness](#filter-projection) for the definition of falsy values.
+
+`!` binds to the immediate next operand only — it does not extend through access operators. `!foo.bar` parses as `(!foo).bar`, not `!(foo.bar)`. Use parentheses for the latter: `!(foo.bar)`.
+
+### Logical AND
+
+**Syntax**: `a && b` &emsp; **Precedence**: 4
+
+Short-circuit evaluation. Returns `a` if `a` is falsy, otherwise returns `b`. Does _not_ coerce to boolean.
+
+```
+name && name.first    # null if name is falsy, otherwise name.first
+```
+
+### Logical OR
+
+**Syntax**: `a || b` &emsp; **Precedence**: 5
+
+Short-circuit evaluation. Returns `a` if `a` is truthy, otherwise returns `b`. Does _not_ coerce to boolean.
+
+```
+nickname || name      # nickname if truthy, otherwise name
+items || `[]`         # default to empty array
+```
+
+---
+
+## Control Flow
+
+### Pipe
+
+**Syntax**: `a | b` &emsp; **Precedence**: 7
+
+Evaluates `a`, then evaluates `b` with the result of `a` as the new current context. Resets the projection context — projections terminate at a pipe.
+
+```
+people[*].name | sort(@)       # sort the projected names
+items[?active] | [0]           # first active item
+```
+
+### Ternary
+
+**Syntax**: `condition ? consequent : alternate` &emsp; **Precedence**: 6
+
+Evaluates `condition`. If truthy, evaluates and returns `consequent`; otherwise evaluates and returns `alternate`. Right-associative: `a ? b : c ? d : e` parses as `a ? b : (c ? d : e)`.
+
+```
+age >= 18 ? 'adult' : 'minor'
+```
+
+---
+
+## Multi-Select
+
+### Multi-Select List
+
+**Syntax**: `[expr, expr, ...]`
+
+Evaluates each expression against the current context and returns the results as an array.
+
+```
+[name, age, email]                # array of three values
+people[*].[name, age]             # for each person, array of name and age
+```
+
+### Multi-Select Hash
+
+**Syntax**: `{key: expr, key: expr, ...}`
+
+Evaluates each expression against the current context and returns an object with the given keys.
+
+```
+{name: name, years: age}
+people[*].{fullName: name, yearsOld: age}
+```
+
+---
+
+## Variables and Let
+
+### Variable References
+
+**Syntax**: `$name`
+
+References a lexical-scope variable bound by a `let` expression. Throws `UndefinedVariableError` if the variable is not in scope. The `$` prefix distinguishes variables from identifiers.
+
+### Let Expressions
+
+**Syntax**: `let $var = expr [, $var2 = expr2, ...] in body` &emsp; **Precedence**: 8
+
+Binds one or more variables and evaluates `body` with those bindings in scope. All binding values are evaluated in the _outer_ scope (not sequentially — earlier bindings are not visible to later ones in the same `let`).
+
+Variables use lexical scoping: inner `let` expressions can shadow outer bindings. `let` and `in` are contextual keywords, not reserved identifiers.
+
+```
+let $threshold = settings.min_age in people[?age >= $threshold]
+let $x = `1`, $y = `2` in [$x, $y]
+```
+
+---
+
+## Function Calls
+
+**Syntax**: `name(arg1, arg2, ...)`
+
+Calls a built-in or registered function. See the [Function Reference](functions.md) for all built-in functions.
+
+Arguments are evaluated before being passed. Function argument types are validated at runtime; type mismatches throw `InvalidArgumentTypeError`.
+
+### Expression References
+
+**Syntax**: `&expr`
+
+Creates an unevaluated reference to an expression. Used as arguments to higher-order functions like `sort_by`, `max_by`, `min_by`, `group_by`, and `map`.
+
+```
+sort_by(people, &age)             # sort by age field
+map(&to_upper(@), names)          # uppercase each name
+```
+
+---
+
+## Extensions
+
+### ID-Based Access (Extension)
+
+`expr['id']` selects the first array element whose `id` property matches the given raw string. Formally equivalent to `expr[?id == 'id'] | [0]`.
+
+This is unambiguous with standard JMESPath because bracket expressions normally only accept numeric indices, not raw strings.
+
+### Bare Numeric Literals (Extension)
+
+Numeric literals can appear without backtick delimiters in expression position. This enables natural arithmetic (`a - 1`, `price > 0`) without requiring `` `1` `` or `` `0` ``.
+
+The parser resolves ambiguity with negative array indices: `-` is always tokenized as an operator, and negative index/slice values are parsed explicitly within bracket grammar. Unary sign on numeric literals is folded at parse time.
+
+---
+
+## Legacy Compatibility
+
+Three parser/evaluation options control backward-compatible behavior:
+
+| Option                   | Scope      | Default | Effect                                                                          |
+| ------------------------ | ---------- | ------- | ------------------------------------------------------------------------------- |
+| `legacyLiterals`         | Parser     | `false` | Invalid JSON in backticks falls back to string (e.g., `` `foo` `` → `"foo"`)    |
+| `legacyRawStringEscapes` | Parser     | `false` | Only `\'` is unescaped in raw strings; `\\` stays literal                       |
+| `legacyNullPropagation`  | Evaluation | `false` | Multi-select on `null` context returns `null` instead of evaluating expressions |
+
+Default behavior follows JMESPath Community Edition semantics. Enable these options for compatibility with original JMESPath behavior.

--- a/src/access-internal.ts
+++ b/src/access-internal.ts
@@ -1,0 +1,60 @@
+import { JsonSelector } from "./ast";
+import { evaluateJsonSelector, normalizeSlice } from "./evaluate";
+import type { EvaluationContext } from "./evaluation-context";
+import { isFalseOrEmpty } from "./util";
+
+export function replaceArray(
+  target: unknown[],
+  source: readonly unknown[],
+): unknown[] {
+  target.length = 0;
+  target.push(...source);
+  return target;
+}
+
+export function invertedFilter(
+  value: unknown[],
+  condition: JsonSelector,
+  evalCtx: EvaluationContext,
+): unknown[] {
+  return value.filter((e) =>
+    isFalseOrEmpty(evaluateJsonSelector(condition, e, evalCtx)),
+  );
+}
+
+/** Returns the complement of a slice: the elements that would NOT be selected by the given slice parameters. */
+export function invertedSlice(
+  value: unknown[],
+  start: number | undefined,
+  end?: number,
+  step?: number,
+): unknown[] {
+  ({ start, end, step } = normalizeSlice(value.length, start, end, step));
+  const collected: unknown[] = [];
+  if (step > 0) {
+    if (start >= end) {
+      return value;
+    }
+    let skip = start;
+    for (let i = 0; i < value.length; ++i) {
+      if (i < skip || i >= end) {
+        collected.push(value[i]);
+      } else {
+        skip += step;
+      }
+    }
+  } else {
+    if (start <= end) {
+      return value;
+    }
+    let skip = start;
+    for (let i = value.length - 1; i >= 0; --i) {
+      if (i > skip || i <= end) {
+        collected.push(value[i]);
+      } else {
+        skip += step;
+      }
+    }
+  }
+  return collected;
+}

--- a/src/access.ts
+++ b/src/access.ts
@@ -1,3 +1,4 @@
+import { invertedFilter, invertedSlice, replaceArray } from "./access-internal";
 import { JsonSelector } from "./ast";
 import {
   compare,
@@ -5,7 +6,6 @@ import {
   filter,
   flatten,
   isIdentityProjection,
-  normalizeSlice,
   objectProject,
   performArithmetic,
   performUnaryArithmetic,
@@ -701,60 +701,4 @@ export function accessWithJsonSelector(
     context,
     rootContext,
   );
-}
-
-function replaceArray(
-  target: unknown[],
-  source: readonly unknown[],
-): unknown[] {
-  target.length = 0;
-  target.push(...source);
-  return target;
-}
-
-function invertedFilter(
-  value: unknown[],
-  condition: JsonSelector,
-  evalCtx: EvaluationContext,
-): unknown[] {
-  return value.filter((e) =>
-    isFalseOrEmpty(evaluateJsonSelector(condition, e, evalCtx)),
-  );
-}
-
-/** Returns the complement of a slice: the elements that would NOT be selected by the given slice parameters. */
-export function invertedSlice(
-  value: unknown[],
-  start: number | undefined,
-  end?: number,
-  step?: number,
-): unknown[] {
-  ({ start, end, step } = normalizeSlice(value.length, start, end, step));
-  const collected: unknown[] = [];
-  if (step > 0) {
-    if (start >= end) {
-      return value;
-    }
-    let skip = start;
-    for (let i = 0; i < value.length; ++i) {
-      if (i < skip || i >= end) {
-        collected.push(value[i]);
-      } else {
-        skip += step;
-      }
-    }
-  } else {
-    if (start <= end) {
-      return value;
-    }
-    let skip = start;
-    for (let i = value.length - 1; i >= 0; --i) {
-      if (i > skip || i <= end) {
-        collected.push(value[i]);
-      } else {
-        skip += step;
-      }
-    }
-  }
-  return collected;
 }

--- a/test/access-internal.test.ts
+++ b/test/access-internal.test.ts
@@ -1,0 +1,51 @@
+import { invertedSlice } from "../src/access-internal";
+
+describe("invertedSlice", () => {
+  test("positive step: returns elements outside [start, end)", () => {
+    // [0,1,2,3,4], slice [1:3] = [1,2], inverted = [0,3,4]
+    expect(invertedSlice([0, 1, 2, 3, 4], 1, 3)).toStrictEqual([0, 3, 4]);
+  });
+
+  test("positive step: start >= end returns original", () => {
+    expect(invertedSlice([0, 1, 2, 3, 4], 3, 1)).toStrictEqual([0, 1, 2, 3, 4]);
+    expect(invertedSlice([0, 1, 2, 3, 4], 2, 2)).toStrictEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("positive step with step > 1", () => {
+    // [0,1,2,3,4,5], slice [::2] = [0,2,4], inverted = [1,3,5]
+    expect(invertedSlice([0, 1, 2, 3, 4, 5], 0, 6, 2)).toStrictEqual([1, 3, 5]);
+  });
+
+  test("negative step: returns elements outside (end, start]", () => {
+    // [0,1,2,3,4], slice [3:0:-1] = [3,2,1], inverted = [4,0] (reversed order)
+    expect(invertedSlice([0, 1, 2, 3, 4], 3, 0, -1)).toStrictEqual([4, 0]);
+  });
+
+  test("negative step: start <= end returns original", () => {
+    expect(invertedSlice([0, 1, 2, 3, 4], 1, 3, -1)).toStrictEqual([
+      0, 1, 2, 3, 4,
+    ]);
+    expect(invertedSlice([0, 1, 2, 3, 4], 2, 2, -1)).toStrictEqual([
+      0, 1, 2, 3, 4,
+    ]);
+  });
+
+  test("negative step with |step| > 1", () => {
+    // [0,1,2,3,4,5], slice [::-2] starting at 5, gets [5,3,1]
+    // inverted = [0,2,4] but collected in reverse order
+    const result = invertedSlice([0, 1, 2, 3, 4, 5], undefined, undefined, -2);
+    expect(result).toStrictEqual([4, 2, 0]);
+  });
+
+  test("empty array", () => {
+    expect(invertedSlice([], 0, 5)).toStrictEqual([]);
+  });
+
+  test("slice entire array leaves nothing", () => {
+    expect(invertedSlice([0, 1, 2], 0, 3)).toStrictEqual([]);
+  });
+
+  test("slice nothing leaves everything", () => {
+    expect(invertedSlice([0, 1, 2], 0, 0)).toStrictEqual([0, 1, 2]);
+  });
+});

--- a/test/access.test.ts
+++ b/test/access.test.ts
@@ -1,7 +1,6 @@
 import {
   accessWithJsonSelector,
   bindJsonSelectorAccessor,
-  invertedSlice,
   makeJsonSelectorAccessor,
 } from "../src/access";
 import { NUMBER_TYPE } from "../src/functions/datatype";
@@ -1615,56 +1614,6 @@ describe("makeJsonSelectorAccessor", () => {
       const acc2 = makeJsonSelectorAccessor(selector2);
       expect(acc2.get(obj)).toBeNull();
     });
-  });
-});
-
-describe("invertedSlice", () => {
-  test("positive step: returns elements outside [start, end)", () => {
-    // [0,1,2,3,4], slice [1:3] = [1,2], inverted = [0,3,4]
-    expect(invertedSlice([0, 1, 2, 3, 4], 1, 3)).toStrictEqual([0, 3, 4]);
-  });
-
-  test("positive step: start >= end returns original", () => {
-    expect(invertedSlice([0, 1, 2, 3, 4], 3, 1)).toStrictEqual([0, 1, 2, 3, 4]);
-    expect(invertedSlice([0, 1, 2, 3, 4], 2, 2)).toStrictEqual([0, 1, 2, 3, 4]);
-  });
-
-  test("positive step with step > 1", () => {
-    // [0,1,2,3,4,5], slice [::2] = [0,2,4], inverted = [1,3,5]
-    expect(invertedSlice([0, 1, 2, 3, 4, 5], 0, 6, 2)).toStrictEqual([1, 3, 5]);
-  });
-
-  test("negative step: returns elements outside (end, start]", () => {
-    // [0,1,2,3,4], slice [3:0:-1] = [3,2,1], inverted = [4,0] (reversed order)
-    expect(invertedSlice([0, 1, 2, 3, 4], 3, 0, -1)).toStrictEqual([4, 0]);
-  });
-
-  test("negative step: start <= end returns original", () => {
-    expect(invertedSlice([0, 1, 2, 3, 4], 1, 3, -1)).toStrictEqual([
-      0, 1, 2, 3, 4,
-    ]);
-    expect(invertedSlice([0, 1, 2, 3, 4], 2, 2, -1)).toStrictEqual([
-      0, 1, 2, 3, 4,
-    ]);
-  });
-
-  test("negative step with |step| > 1", () => {
-    // [0,1,2,3,4,5], slice [::-2] starting at 5, gets [5,3,1]
-    // inverted = [0,2,4] but collected in reverse order
-    const result = invertedSlice([0, 1, 2, 3, 4, 5], undefined, undefined, -2);
-    expect(result).toStrictEqual([4, 2, 0]);
-  });
-
-  test("empty array", () => {
-    expect(invertedSlice([], 0, 5)).toStrictEqual([]);
-  });
-
-  test("slice entire array leaves nothing", () => {
-    expect(invertedSlice([0, 1, 2], 0, 3)).toStrictEqual([]);
-  });
-
-  test("slice nothing leaves everything", () => {
-    expect(invertedSlice([0, 1, 2], 0, 0)).toStrictEqual([0, 1, 2]);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds comprehensive user-facing reference documentation to the library, streamlines the README, and refactors internal helper functions to an internal-only module.

Creates four new documentation files (docs/language.md, docs/functions.md, docs/api.md, docs/benchmark.md) covering the expression language, all 43 built-in functions, the TypeScript API, and the benchmark CLI. Streamlines README.md to link to documentation instead of duplicating content.

Moves invertedSlice, invertedFilter, and replaceArray to a new src/access-internal.ts module to avoid exporting internal helpers, while preserving test coverage by moving invertedSlice tests to test/access-internal.test.ts.

## Changes

- **docs/language.md**: Expression language reference with precedence tables, operator details, literal syntax, projections, context, and legacy compatibility options
- **docs/functions.md**: 43 built-in functions (Type, String, Math, Array/Object) with signatures, descriptions, edge cases, Unicode handling, and error conditions
- **docs/api.md**: TypeScript API reference including core functions, accessors, visitor pattern, function system, error hierarchy, and AST node reference
- **docs/benchmark.md**: Benchmark CLI usage guide with options, library comparison, result saving/comparing, and tuning
- **README.md**: Streamlined to installation, quick start, and documentation links; removed duplicated content
- **src/access-internal.ts**: New internal module with replaceArray, invertedFilter, invertedSlice (not exported from package)
- **src/access.ts**: Updated to import from access-internal.ts; removed inline helper function definitions
- **test/access-internal.test.ts**: New test file with comprehensive invertedSlice test suite
- **test/access.test.ts**: Removed invertedSlice tests (moved to access-internal.test.ts)