### PR TITLE
Rename legacy ParserOptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,8 @@ npx jest test/parse.test.ts
 
 - `test/jmespath/*`: official `jmespath.test` fixtures.
 - `test/jmespath-community/*`: community deltas and additions.
-- Core JMESPath fixtures (`test/jmespath/*`) run with compatibility options enabled: `legacyRawStringEscapes` (parser) and `legacyNullPropagation` (evaluation).
-- Legacy community literal fixtures (`test/jmespath-community/legacy/*`) run with `legacyLiterals` enabled; other community fixtures run in modern mode.
+- Core JMESPath fixtures (`test/jmespath/*`) run with compatibility options: `rawStringBackslashEscape: false` (parser) and `evaluateNullMultiSelect: false` (evaluation).
+- Legacy community literal fixtures (`test/jmespath-community/legacy/*`) run with default permissive behavior; other community fixtures run with `strictJsonLiterals: true`.
 
 **Supported Features**:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Two extensions are added:
 - **ID-based access**: `x['id']` selects the first array element whose `id` property matches — equivalent to `x[?id == 'id'] | [0]` in standard JMESPath.
 - **Bare numeric literals**: Numbers like `0`, `-1`, `3.14` can appear directly in expressions without backtick delimiters, enabling natural syntax like `foo[?price > 0]` and `a - 1`.
 
-Legacy compatibility options (`legacyLiterals`, `legacyRawStringEscapes`, `legacyNullPropagation`) are available for original JMESPath behavior. See the [Language Reference](docs/language.md#legacy-compatibility) for details.
+Compatibility options (`strictJsonLiterals`, `rawStringBackslashEscape`, `evaluateNullMultiSelect`) control standards-compliance behavior. See the [Language Reference](docs/language.md#legacy-compatibility) for details.
 
 ## License
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -71,10 +71,10 @@ Parses an expression string into an AST. Throws a `JsonSelectorSyntaxError` subc
 
 **`ParserOptions`**
 
-| Field                    | Type      | Default | Description                                                             |
-| ------------------------ | --------- | ------- | ----------------------------------------------------------------------- |
-| `legacyLiterals`         | `boolean` | `false` | Enable legacy backtick-literal fallback (invalid JSON becomes a string) |
-| `legacyRawStringEscapes` | `boolean` | `false` | Only unescape `\'` in raw strings (not `\\`)                            |
+| Field                      | Type      | Default | Description                                                                        |
+| -------------------------- | --------- | ------- | ---------------------------------------------------------------------------------- |
+| `strictJsonLiterals`       | `boolean` | `false` | Require valid JSON in backtick literals; throw instead of falling back to a string |
+| `rawStringBackslashEscape` | `boolean` | `true`  | Enable backslash escape in raw strings (both `\'` and `\\` are unescaped)          |
 
 ### `evaluateJsonSelector`
 
@@ -90,12 +90,12 @@ Evaluates a parsed selector against `context` and returns the result. The option
 
 **`EvaluationContext`**
 
-| Field                   | Type                           | Default            | Description                                                 |
-| ----------------------- | ------------------------------ | ------------------ | ----------------------------------------------------------- |
-| `rootContext`           | `unknown`                      | `context`          | The root document, accessible via `$`                       |
-| `functionProvider`      | `FunctionProvider`             | Built-in functions | Function lookup table                                       |
-| `bindings`              | `ReadonlyMap<string, unknown>` | —                  | Pre-bound lexical variables                                 |
-| `legacyNullPropagation` | `boolean`                      | `false`            | Multi-select on `null` returns `null` instead of evaluating |
+| Field                     | Type                           | Default            | Description                                                                     |
+| ------------------------- | ------------------------------ | ------------------ | ------------------------------------------------------------------------------- |
+| `rootContext`             | `unknown`                      | `context`          | The root document, accessible via `$`                                           |
+| `functionProvider`        | `FunctionProvider`             | Built-in functions | Function lookup table                                                           |
+| `bindings`                | `ReadonlyMap<string, unknown>` | —                  | Pre-bound lexical variables                                                     |
+| `evaluateNullMultiSelect` | `boolean`                      | `true`             | Evaluate multi-select expressions on `null` context instead of short-circuiting |
 
 A deprecated overload accepting `(selector, context, rootContext, options)` still exists for backward compatibility.
 
@@ -133,11 +133,11 @@ Compiles and binds a selector in one step. Returns a bound `Accessor`.
 
 **`AccessorOptions`**
 
-| Field                   | Type                           | Default            | Description                                                |
-| ----------------------- | ------------------------------ | ------------------ | ---------------------------------------------------------- |
-| `functionProvider`      | `FunctionProvider`             | Built-in functions | Function lookup table for evaluation                       |
-| `bindings`              | `ReadonlyMap<string, unknown>` | —                  | Lexical-scope variable bindings (name without `$` → value) |
-| `legacyNullPropagation` | `boolean`                      | `false`            | Propagate `null` through multi-select expressions          |
+| Field                     | Type                           | Default            | Description                                                                     |
+| ------------------------- | ------------------------------ | ------------------ | ------------------------------------------------------------------------------- |
+| `functionProvider`        | `FunctionProvider`             | Built-in functions | Function lookup table for evaluation                                            |
+| `bindings`                | `ReadonlyMap<string, unknown>` | —                  | Lexical-scope variable bindings (name without `$` → value)                      |
+| `evaluateNullMultiSelect` | `boolean`                      | `true`             | Evaluate multi-select expressions on `null` context instead of short-circuiting |
 
 ### `makeJsonSelectorAccessor`
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -114,7 +114,7 @@ Embeds a constant JSON value. The content between backticks must be valid JSON. 
 
 Note: the backtick content must be valid JSON, so strings require inner quotes: `` `"hello"` ``, not `` `hello` ``.
 
-With `legacyLiterals` enabled, invalid JSON inside backticks falls back to a string (e.g., `` `foo` `` becomes `"foo"`).
+By default, invalid JSON inside backticks falls back to a string (e.g., `` `foo` `` becomes `"foo"`). With `strictJsonLiterals` enabled, invalid JSON throws a syntax error instead.
 
 ### Raw Strings
 
@@ -128,7 +128,7 @@ A string literal where the content is taken verbatim. Escape single quotes with 
 'backslash: \\'
 ```
 
-With `legacyRawStringEscapes` enabled, only `\'` is unescaped; `\\` remains literal.
+With `rawStringBackslashEscape` disabled, only `\'` is unescaped; `\\` remains literal.
 
 ### Quoted Strings
 
@@ -497,12 +497,12 @@ The parser resolves ambiguity with negative array indices: `-` is always tokeniz
 
 ## Legacy Compatibility
 
-Three parser/evaluation options control backward-compatible behavior:
+Three parser/evaluation options control standards-compliance behavior:
 
-| Option                   | Scope      | Default | Effect                                                                          |
-| ------------------------ | ---------- | ------- | ------------------------------------------------------------------------------- |
-| `legacyLiterals`         | Parser     | `false` | Invalid JSON in backticks falls back to string (e.g., `` `foo` `` → `"foo"`)    |
-| `legacyRawStringEscapes` | Parser     | `false` | Only `\'` is unescaped in raw strings; `\\` stays literal                       |
-| `legacyNullPropagation`  | Evaluation | `false` | Multi-select on `null` context returns `null` instead of evaluating expressions |
+| Option                     | Scope      | Default | Effect                                                                                    |
+| -------------------------- | ---------- | ------- | ----------------------------------------------------------------------------------------- |
+| `strictJsonLiterals`       | Parser     | `false` | Require valid JSON in backtick literals; throw instead of falling back to a string        |
+| `rawStringBackslashEscape` | Parser     | `true`  | Enable backslash escape in raw strings (both `\'` and `\\` are unescaped)                 |
+| `evaluateNullMultiSelect`  | Evaluation | `true`  | Evaluate multi-select expressions on `null` context instead of short-circuiting to `null` |
 
-Default behavior follows JMESPath Community Edition semantics. Enable these options for compatibility with original JMESPath behavior.
+Default behavior is permissive (backtick fallback enabled, backslash escapes enabled, null multi-select evaluation enabled). For strict JMESPath Community Edition compliance, set `strictJsonLiterals: true`. For original JMESPath compatibility, set `rawStringBackslashEscape: false` and `evaluateNullMultiSelect: false`.

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -34,7 +34,7 @@ function isPartialEvaluationContext(
     ("rootContext" in value ||
       "functionProvider" in value ||
       "bindings" in value ||
-      "legacyNullPropagation" in value)
+      "evaluateNullMultiSelect" in value)
   );
 }
 
@@ -64,7 +64,7 @@ export function evaluateJsonSelector(
       functionProvider:
         evalCtxOrRoot.functionProvider ?? getBuiltinFunctionProvider(),
       bindings: evalCtxOrRoot.bindings,
-      legacyNullPropagation: evalCtxOrRoot.legacyNullPropagation,
+      evaluateNullMultiSelect: evalCtxOrRoot.evaluateNullMultiSelect ?? true,
     };
   } else {
     evalCtx = {
@@ -72,7 +72,7 @@ export function evaluateJsonSelector(
       functionProvider:
         options?.functionProvider ?? getBuiltinFunctionProvider(),
       bindings: options?.bindings,
-      legacyNullPropagation: options?.legacyNullPropagation,
+      evaluateNullMultiSelect: options?.evaluateNullMultiSelect ?? true,
     };
   }
   return evaluate(selector, context, evalCtx);
@@ -206,7 +206,7 @@ function evaluate(
         });
       },
       multiSelectList({ expressions }) {
-        if (evalCtx.legacyNullPropagation && context == null) {
+        if (context == null && !evalCtx.evaluateNullMultiSelect) {
           return null;
         }
         // Default behavior follows JMESPath Community semantics:
@@ -215,7 +215,7 @@ function evaluate(
         return expressions.map((expr) => evaluate(expr, context, evalCtx));
       },
       multiSelectHash({ entries }) {
-        if (evalCtx.legacyNullPropagation && context == null) {
+        if (context == null && !evalCtx.evaluateNullMultiSelect) {
           return null;
         }
         // Default behavior follows JMESPath Community semantics:

--- a/src/evaluation-context.ts
+++ b/src/evaluation-context.ts
@@ -12,6 +12,6 @@ export type EvaluationContext = {
   functionProvider: FunctionProvider;
   /** Lexical-scope variable bindings (name without `$` -> value). */
   bindings?: ReadonlyMap<string, unknown>;
-  /** Enables legacy null propagation for multi-select expressions. */
-  legacyNullPropagation?: boolean;
+  /** Evaluates multi-select expressions on null context instead of short-circuiting to null. Defaults to true. */
+  evaluateNullMultiSelect?: boolean;
 };

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -38,8 +38,8 @@ const ESCAPE_CHARS: Record<string, string> = {
 };
 
 export interface LexerOptions {
-  /** Enables legacy raw-string escapes (only \' is unescaped). */
-  legacyRawStringEscapes?: boolean;
+  /** Enables backslash escape in raw strings (both \' and \\ are unescaped). Defaults to true. */
+  rawStringBackslashEscape?: boolean;
 }
 
 /**
@@ -49,14 +49,14 @@ export interface LexerOptions {
 export class Lexer {
   private readonly input: string;
   private readonly length: number;
-  private readonly legacyRawStringEscapes: boolean;
+  private readonly rawStringBackslashEscape: boolean;
   private pos: number = 0;
   private current: Token;
 
   constructor(input: string, options?: LexerOptions) {
     this.input = input;
     this.length = input.length;
-    this.legacyRawStringEscapes = options?.legacyRawStringEscapes === true;
+    this.rawStringBackslashEscape = options?.rawStringBackslashEscape ?? true;
     this.current = this.scanNext();
   }
 
@@ -363,8 +363,8 @@ export class Lexer {
 
   /**
    * Scan raw string: '...'
-   * Handles \' and \\ escapes by default.
-   * In legacy mode, only \' is unescaped.
+   * When rawStringBackslashEscape is true (default), both \' and \\ are unescaped.
+   * When false, only \' is unescaped.
    * Optimized to use slicing for long strings
    */
   private scanRawString(start: number): StringToken {
@@ -398,9 +398,9 @@ export class Lexer {
     let value = this.input.slice(startPos, endPos);
 
     if (hasEscape) {
-      value = this.legacyRawStringEscapes
-        ? value.replace(/\\'/g, "'")
-        : value.replace(/\\([\\'])/g, "$1");
+      value = this.rawStringBackslashEscape
+        ? value.replace(/\\([\\'])/g, "$1")
+        : value.replace(/\\'/g, "'");
     }
 
     this.pos = endPos + 1;

--- a/test/evaluate.test.ts
+++ b/test/evaluate.test.ts
@@ -76,10 +76,10 @@ describe("evaluate", () => {
     expect(evaluateJsonSelector(selector, null)).toStrictEqual([null, null]);
   });
 
-  test("multiSelectList returns null in legacy null-propagation mode", () => {
+  test("multiSelectList returns null when evaluateNullMultiSelect is disabled", () => {
     const selector = parseJsonSelector("[a, b]");
     expect(
-      evaluateJsonSelector(selector, null, { legacyNullPropagation: true }),
+      evaluateJsonSelector(selector, null, { evaluateNullMultiSelect: false }),
     ).toBeNull();
   });
 
@@ -91,10 +91,21 @@ describe("evaluate", () => {
     });
   });
 
-  test("multiSelectHash returns null in legacy null-propagation mode", () => {
+  test("multiSelectHash returns null when evaluateNullMultiSelect is disabled", () => {
     const selector = parseJsonSelector("{x: a, y: b}");
     expect(
-      evaluateJsonSelector(selector, null, { legacyNullPropagation: true }),
+      evaluateJsonSelector(selector, null, { evaluateNullMultiSelect: false }),
+    ).toBeNull();
+  });
+
+  test("multiSelectList returns null via deprecated overload with evaluateNullMultiSelect disabled", () => {
+    const selector = parseJsonSelector("[a, b]");
+    expect(
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- testing legacy overload
+      evaluateJsonSelector(selector, null, null, {
+        functionProvider: getBuiltinFunctionProvider(),
+        evaluateNullMultiSelect: false,
+      }),
     ).toBeNull();
   });
 

--- a/test/jmespath.test.ts
+++ b/test/jmespath.test.ts
@@ -121,12 +121,15 @@ function addTestSuitesFromFile(filename: string) {
 function getFixtureSearchOptions(filename: string): SearchOptions | undefined {
   if (/test\/jmespath\//.test(filename)) {
     return {
-      evalCtx: { legacyNullPropagation: true },
-      parserOptions: { legacyRawStringEscapes: true },
+      evalCtx: { evaluateNullMultiSelect: false },
+      parserOptions: { rawStringBackslashEscape: false },
     };
   }
   if (/test\/jmespath-community\/legacy\//.test(filename)) {
-    return { parserOptions: { legacyLiterals: true } };
+    return undefined; // default permissive behavior
+  }
+  if (/test\/jmespath-community\//.test(filename)) {
+    return { parserOptions: { strictJsonLiterals: true } };
   }
   return undefined;
 }

--- a/test/lexer.test.ts
+++ b/test/lexer.test.ts
@@ -214,9 +214,9 @@ describe("Lexer", () => {
         });
       });
 
-      test("keeps \\\\ in raw strings in legacyRawStringEscapes mode", () => {
+      test("keeps \\\\ in raw strings when rawStringBackslashEscape is disabled", () => {
         expect(
-          tokenize(String.raw`'\\'`, { legacyRawStringEscapes: true }),
+          tokenize(String.raw`'\\'`, { rawStringBackslashEscape: false }),
         ).toMatchObject({
           type: TokenType.RAW_STRING,
           value: "\\\\",

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -591,9 +591,11 @@ describe("parseJsonSelector", () => {
       });
     });
 
-    test("raw string preserves \\\\ in legacyRawStringEscapes mode", () => {
+    test("raw string preserves \\\\ when rawStringBackslashEscape is disabled", () => {
       expect(
-        parseJsonSelector(String.raw`'\\'`, { legacyRawStringEscapes: true }),
+        parseJsonSelector(String.raw`'\\'`, {
+          rawStringBackslashEscape: false,
+        }),
       ).toStrictEqual<JsonSelector>({
         type: "literal",
         value: "\\\\",
@@ -656,22 +658,22 @@ describe("parseJsonSelector", () => {
       });
     });
 
-    test("backtick invalid JSON throws syntax by default", () => {
-      const error = catchError(() => parseJsonSelector("`invalid`"));
+    test("backtick invalid JSON falls back to string by default", () => {
+      expect(parseJsonSelector("`invalid`")).toStrictEqual<JsonSelector>({
+        type: "literal",
+        value: "invalid",
+        backtickSyntax: true,
+      });
+    });
+
+    test("backtick invalid JSON throws syntax in strict mode", () => {
+      const error = catchError(() =>
+        parseJsonSelector("`invalid`", { strictJsonLiterals: true }),
+      );
       expect(error).toMatchObject({
         name: "InvalidTokenError",
         expression: "`invalid`",
         tokenKind: "JSON literal",
-      });
-    });
-
-    test("backtick invalid JSON falls back to string in legacy mode", () => {
-      expect(
-        parseJsonSelector("`invalid`", { legacyLiterals: true }),
-      ).toStrictEqual<JsonSelector>({
-        type: "literal",
-        value: "invalid",
-        backtickSyntax: true,
       });
     });
   });


### PR DESCRIPTION
Rename three ParserOptions with inverted defaults to be more discoverable and favor permissive behavior: `legacyLiterals` → `strictJsonLiterals`, `legacyRawStringEscapes` → `rawStringBackslashEscape`, and `legacyNullPropagation` → `evaluateNullMultiSelect`. The new names describe what they enable/require rather than framing behavior as "legacy". Inverted defaults preserve the old default behavior while making the API less surprising—strict JMESPath compliance now requires explicit opt-in, and permissive Community Edition semantics are the default.

Updates source code (parser, lexer, evaluation context, evaluator), tests (fixing fixture options to match new semantics), and all documentation (CLAUDE.md, README, API docs, language docs).