### PR TITLE
LC-16726: Add lowNotPrecedence parser option for JavaScript-like NOT precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @loancrate/json-selector
 
+## 5.2.0
+
+### Minor Changes
+
+- Add `lowNotPrecedence` parser option that makes `!` (logical NOT) bind below member access, brackets, flatten, and filter operators, matching JavaScript's precedence rules. When enabled, `!foo.bar` parses as `!(foo.bar)` instead of the default `(!foo).bar`. The default (`false`) preserves existing JMESPath-standard behavior.
+
 ## 5.1.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Two extensions are added:
 - **ID-based access**: `x['id']` selects the first array element whose `id` property matches — equivalent to `x[?id == 'id'] | [0]` in standard JMESPath.
 - **Bare numeric literals**: Numbers like `0`, `-1`, `3.14` can appear directly in expressions without backtick delimiters, enabling natural syntax like `foo[?price > 0]` and `a - 1`.
 
-Compatibility options (`strictJsonLiterals`, `rawStringBackslashEscape`, `evaluateNullMultiSelect`) control standards-compliance behavior. See the [Language Reference](docs/language.md#legacy-compatibility) for details.
+Compatibility options (`strictJsonLiterals`, `rawStringBackslashEscape`, `lowNotPrecedence`, `evaluateNullMultiSelect`) control standards-compliance behavior. See the [Language Reference](docs/language.md#legacy-compatibility) for details.
 
 ## License
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,6 +76,7 @@ Parses an expression string into an AST. Throws a `JsonSelectorSyntaxError` subc
 | -------------------------- | --------- | ------- | ---------------------------------------------------------------------------------- |
 | `strictJsonLiterals`       | `boolean` | `false` | Require valid JSON in backtick literals; throw instead of falling back to a string |
 | `rawStringBackslashEscape` | `boolean` | `true`  | Enable backslash escape in raw strings (both `\'` and `\\` are unescaped)          |
+| `lowNotPrecedence`         | `boolean` | `false` | Make `!` bind below member access, matching JavaScript precedence                  |
 
 ### `evaluateJsonSelector`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,11 +72,11 @@ Parses an expression string into an AST. Throws a `JsonSelectorSyntaxError` subc
 
 **`ParserOptions`**
 
-| Field                      | Type      | Default | Description                                                                        |
-| -------------------------- | --------- | ------- | ---------------------------------------------------------------------------------- |
-| `strictJsonLiterals`       | `boolean` | `false` | Require valid JSON in backtick literals; throw instead of falling back to a string |
-| `rawStringBackslashEscape` | `boolean` | `true`  | Enable backslash escape in raw strings (both `\'` and `\\` are unescaped)          |
-| `lowNotPrecedence`         | `boolean` | `false` | Make `!` bind below member access, matching JavaScript precedence                  |
+| Field                      | Type      | Default | Description                                                                                  |
+| -------------------------- | --------- | ------- | -------------------------------------------------------------------------------------------- |
+| `strictJsonLiterals`       | `boolean` | `false` | Require valid JSON in backtick literals; throw instead of falling back to a string           |
+| `rawStringBackslashEscape` | `boolean` | `true`  | Enable backslash escape in raw strings (both `\'` and `\\` are unescaped)                    |
+| `lowNotPrecedence`         | `boolean` | `false` | Make `!` bind below member access, matching JavaScript precedence (restores pre-v4 behavior) |
 
 ### `evaluateJsonSelector`
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -26,10 +26,10 @@ Precedence is numbered 1 (tightest) through 8 (loosest). Prefix and postfix oper
 
 **Prefix operators** apply to the expression immediately to their right:
 
-| Group                         | Element                               | Syntax           | Binding                                   |
-| ----------------------------- | ------------------------------------- | ---------------- | ----------------------------------------- |
-| [Logical](#logical-operators) | [Logical NOT](#logical-not)           | `!expr`          | Immediate operand only: `!a.b` = `(!a).b` |
-| [Arithmetic](#arithmetic)     | [Unary plus/minus](#unary-arithmetic) | `+expr`, `-expr` | Through access: `-a.b` = `-(a.b)`         |
+| Group                         | Element                               | Syntax           | Binding                                                                                                    |
+| ----------------------------- | ------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------- |
+| [Logical](#logical-operators) | [Logical NOT](#logical-not)           | `!expr`          | Immediate operand only by default: `!a.b` = `(!a).b`<br>With `lowNotPrecedence` enabled: `!a.b` = `!(a.b)` |
+| [Arithmetic](#arithmetic)     | [Unary plus/minus](#unary-arithmetic) | `+expr`, `-expr` | Through access: `-a.b` = `-(a.b)`                                                                          |
 
 **Postfix / access operators** chain left-to-right and bind tighter than all binary operators:
 
@@ -359,7 +359,9 @@ Numeric ordering. Both operands must be numbers. If either operand is not a numb
 
 Returns `true` if `expr` is falsy, `false` otherwise. See [truthiness](#filter-projection) for the definition of falsy values.
 
-`!` binds to the immediate next operand only — it does not extend through access operators. `!foo.bar` parses as `(!foo).bar`, not `!(foo.bar)`. Use parentheses for the latter: `!(foo.bar)`.
+`!` binds to the immediate next operand only by default — it does not extend through access operators. `!foo.bar` parses as `(!foo).bar`, not `!(foo.bar)`. Use parentheses for the latter: `!(foo.bar)`.
+
+With `lowNotPrecedence` enabled, `!` binds below member access, bracket access, flatten, and filter (like JavaScript's `!`), so `!foo.bar` parses as `!(foo.bar)`.
 
 ### Logical AND
 
@@ -497,12 +499,13 @@ The parser resolves ambiguity with negative array indices: `-` is always tokeniz
 
 ## Legacy Compatibility
 
-Three parser/evaluation options control standards-compliance behavior:
+Four parser/evaluation options control standards-compliance behavior:
 
-| Option                     | Scope      | Default | Effect                                                                                    |
-| -------------------------- | ---------- | ------- | ----------------------------------------------------------------------------------------- |
-| `strictJsonLiterals`       | Parser     | `false` | Require valid JSON in backtick literals; throw instead of falling back to a string        |
-| `rawStringBackslashEscape` | Parser     | `true`  | Enable backslash escape in raw strings (both `\'` and `\\` are unescaped)                 |
-| `evaluateNullMultiSelect`  | Evaluation | `true`  | Evaluate multi-select expressions on `null` context instead of short-circuiting to `null` |
+| Option                     | Scope      | Default | Effect                                                                                      |
+| -------------------------- | ---------- | ------- | ------------------------------------------------------------------------------------------- |
+| `strictJsonLiterals`       | Parser     | `false` | Require valid JSON in backtick literals; throw instead of falling back to a string          |
+| `rawStringBackslashEscape` | Parser     | `true`  | Enable backslash escape in raw strings (both `\'` and `\\` are unescaped)                   |
+| `lowNotPrecedence`         | Parser     | `false` | Make `!` extend through access operators (like JavaScript), instead of stopping immediately |
+| `evaluateNullMultiSelect`  | Evaluation | `true`  | Evaluate multi-select expressions on `null` context instead of short-circuiting to `null`   |
 
 Default behavior is permissive (backtick fallback enabled, backslash escapes enabled, null multi-select evaluation enabled). For strict JMESPath Community Edition compliance, set `strictJsonLiterals: true`. For original JMESPath compatibility, set `rawStringBackslashEscape: false` and `evaluateNullMultiSelect: false`.

--- a/docs/language.md
+++ b/docs/language.md
@@ -501,11 +501,11 @@ The parser resolves ambiguity with negative array indices: `-` is always tokeniz
 
 Four parser/evaluation options control standards-compliance behavior:
 
-| Option                     | Scope      | Default | Effect                                                                                      |
-| -------------------------- | ---------- | ------- | ------------------------------------------------------------------------------------------- |
-| `strictJsonLiterals`       | Parser     | `false` | Require valid JSON in backtick literals; throw instead of falling back to a string          |
-| `rawStringBackslashEscape` | Parser     | `true`  | Enable backslash escape in raw strings (both `\'` and `\\` are unescaped)                   |
-| `lowNotPrecedence`         | Parser     | `false` | Make `!` extend through access operators (like JavaScript), instead of stopping immediately |
-| `evaluateNullMultiSelect`  | Evaluation | `true`  | Evaluate multi-select expressions on `null` context instead of short-circuiting to `null`   |
+| Option                     | Scope      | Default | Effect                                                                                                                 |
+| -------------------------- | ---------- | ------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `strictJsonLiterals`       | Parser     | `false` | Require valid JSON in backtick literals; throw instead of falling back to a string                                     |
+| `rawStringBackslashEscape` | Parser     | `true`  | Enable backslash escape in raw strings (both `\'` and `\\` are unescaped)                                              |
+| `lowNotPrecedence`         | Parser     | `false` | Make `!` extend through access operators (like JavaScript), instead of stopping immediately (restores pre-v4 behavior) |
+| `evaluateNullMultiSelect`  | Evaluation | `true`  | Evaluate multi-select expressions on `null` context instead of short-circuiting to `null`                              |
 
 Default behavior is permissive (backtick fallback enabled, backslash escapes enabled, null multi-select evaluation enabled). For strict JMESPath Community Edition compliance, set `strictJsonLiterals: true`. For original JMESPath compatibility, set `rawStringBackslashEscape: false` and `evaluateNullMultiSelect: false`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loancrate/json-selector",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@loancrate/json-selector",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "ISC",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loancrate/json-selector",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "LoanCrate JSON Selectors",
   "keywords": [
     "json",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -31,6 +31,7 @@ const BP_AND = 4;
 const BP_COMPARE = 5;
 const BP_ADD = 6;
 const BP_MUL = 7;
+const BP_LOW_NOT = 8;
 const BP_FLATTEN = 9;
 const BP_FILTER = 21;
 const BP_DOT = 40;
@@ -92,6 +93,8 @@ export interface ParserOptions {
   strictJsonLiterals?: boolean;
   /** Enables backslash escape in raw strings (both \' and \\ are unescaped). Defaults to true. */
   rawStringBackslashEscape?: boolean;
+  /** Makes NOT (!) bind below member access, brackets, flatten, and filter (but above arithmetic). Default: false. */
+  lowNotPrecedence?: boolean;
 }
 
 /**
@@ -106,6 +109,7 @@ export class Parser {
   private readonly input: string;
   private readonly lexer: Lexer;
   private readonly strictJsonLiterals: boolean;
+  private readonly notBindingPower: number;
 
   constructor(input: string, options?: ParserOptions) {
     this.input = input;
@@ -113,6 +117,8 @@ export class Parser {
       rawStringBackslashEscape: options?.rawStringBackslashEscape,
     });
     this.strictJsonLiterals = options?.strictJsonLiterals === true;
+    this.notBindingPower =
+      options?.lowNotPrecedence === true ? BP_LOW_NOT : BP_NOT;
   }
 
   /**
@@ -248,7 +254,7 @@ export class Parser {
         this.lexer.advance();
         return {
           type: "not",
-          expression: this.expression(BP_NOT),
+          expression: this.expression(this.notBindingPower),
         };
 
       case TokenType.PLUS:

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -163,6 +163,216 @@ describe("parseJsonSelector", () => {
     });
   });
 
+  describe("lowNotPrecedence", () => {
+    const identifier = (id: string): JsonSelector => ({
+      type: "identifier",
+      id,
+    });
+
+    const current = (): JsonSelector => ({ type: "current" });
+
+    const not = (expression: JsonSelector): JsonSelector => ({
+      type: "not",
+      expression,
+    });
+
+    const fieldAccess = (
+      expression: JsonSelector,
+      field: string,
+    ): JsonSelector => ({
+      type: "fieldAccess",
+      expression,
+      field,
+    });
+
+    const indexAccess = (
+      expression: JsonSelector,
+      index: number,
+    ): JsonSelector => ({
+      type: "indexAccess",
+      expression,
+      index,
+    });
+
+    const flatten = (expression: JsonSelector): JsonSelector => ({
+      type: "flatten",
+      expression,
+    });
+
+    const filter = (
+      expression: JsonSelector,
+      condition: JsonSelector,
+    ): JsonSelector => ({
+      type: "filter",
+      expression,
+      condition,
+    });
+
+    const project = (
+      expression: JsonSelector,
+      projection: JsonSelector,
+    ): JsonSelector => ({
+      type: "project",
+      expression,
+      projection,
+    });
+
+    const arithmetic = (
+      operator: "+" | "*",
+      lhs: JsonSelector,
+      rhs: JsonSelector,
+    ): JsonSelector => ({
+      type: "arithmetic",
+      operator,
+      lhs,
+      rhs,
+    });
+
+    const and = (lhs: JsonSelector, rhs: JsonSelector): JsonSelector => ({
+      type: "and",
+      lhs,
+      rhs,
+    });
+
+    const compareEq = (lhs: JsonSelector, rhs: JsonSelector): JsonSelector => ({
+      type: "compare",
+      operator: "==",
+      lhs,
+      rhs,
+    });
+
+    const changedCases: Array<{
+      expression: string;
+      defaultAst: JsonSelector;
+      lowAst: JsonSelector;
+    }> = [
+      {
+        expression: "!foo.bar",
+        defaultAst: fieldAccess(not(identifier("foo")), "bar"),
+        lowAst: not(fieldAccess(identifier("foo"), "bar")),
+      },
+      {
+        expression: "!foo.bar.baz",
+        defaultAst: fieldAccess(
+          fieldAccess(not(identifier("foo")), "bar"),
+          "baz",
+        ),
+        lowAst: not(fieldAccess(fieldAccess(identifier("foo"), "bar"), "baz")),
+      },
+      {
+        expression: "!foo[0].bar",
+        defaultAst: fieldAccess(not(indexAccess(identifier("foo"), 0)), "bar"),
+        lowAst: not(fieldAccess(indexAccess(identifier("foo"), 0), "bar")),
+      },
+      {
+        expression: "!!foo.bar",
+        defaultAst: fieldAccess(not(not(identifier("foo"))), "bar"),
+        lowAst: not(not(fieldAccess(identifier("foo"), "bar"))),
+      },
+      {
+        expression: "!foo.bar + baz",
+        defaultAst: arithmetic(
+          "+",
+          fieldAccess(not(identifier("foo")), "bar"),
+          identifier("baz"),
+        ),
+        lowAst: arithmetic(
+          "+",
+          not(fieldAccess(identifier("foo"), "bar")),
+          identifier("baz"),
+        ),
+      },
+      {
+        expression: "!foo[]",
+        defaultAst: flatten(not(identifier("foo"))),
+        lowAst: not(flatten(identifier("foo"))),
+      },
+      {
+        expression: "!foo[].bar",
+        defaultAst: project(
+          flatten(not(identifier("foo"))),
+          fieldAccess(current(), "bar"),
+        ),
+        lowAst: not(
+          project(flatten(identifier("foo")), fieldAccess(current(), "bar")),
+        ),
+      },
+      {
+        expression: "!foo[?bar].baz",
+        defaultAst: project(
+          filter(not(identifier("foo")), identifier("bar")),
+          fieldAccess(current(), "baz"),
+        ),
+        lowAst: not(
+          project(
+            filter(identifier("foo"), identifier("bar")),
+            fieldAccess(current(), "baz"),
+          ),
+        ),
+      },
+    ];
+
+    test.each(changedCases)(
+      "keeps the default parse for $expression when disabled",
+      ({ expression, defaultAst }) => {
+        expect(parseJsonSelector(expression)).toStrictEqual<JsonSelector>(
+          defaultAst,
+        );
+      },
+    );
+
+    test.each(changedCases)(
+      "extends NOT through access operators for $expression when enabled",
+      ({ expression, lowAst }) => {
+        expect(
+          parseJsonSelector(expression, { lowNotPrecedence: true }),
+        ).toStrictEqual<JsonSelector>(lowAst);
+      },
+    );
+
+    const unchangedCases: Array<{
+      expression: string;
+      expected: JsonSelector;
+    }> = [
+      {
+        expression: "!foo[0]",
+        expected: not(indexAccess(identifier("foo"), 0)),
+      },
+      {
+        expression: "!foo[*]",
+        expected: not(project(identifier("foo"), current())),
+      },
+      {
+        expression: "!a * b",
+        expected: arithmetic("*", not(identifier("a")), identifier("b")),
+      },
+      {
+        expression: "!a + b",
+        expected: arithmetic("+", not(identifier("a")), identifier("b")),
+      },
+      {
+        expression: "!a && b",
+        expected: and(not(identifier("a")), identifier("b")),
+      },
+      {
+        expression: "!a == b",
+        expected: compareEq(not(identifier("a")), identifier("b")),
+      },
+    ];
+
+    test.each(unchangedCases)(
+      "does not change the parse for $expression",
+      ({ expression, expected }) => {
+        expect(parseJsonSelector(expression)).toStrictEqual<JsonSelector>(
+          expected,
+        );
+        expect(
+          parseJsonSelector(expression, { lowNotPrecedence: true }),
+        ).toStrictEqual<JsonSelector>(expected);
+      },
+    );
+  });
+
   describe("ID access", () => {
     test("id access after field access", () => {
       expect(


### PR DESCRIPTION
Adds a new `lowNotPrecedence` parser option that makes `!` (logical NOT) bind below member access, brackets, flatten, and filter operators, matching JavaScript's precedence rules.

When disabled (default), `!a.b` parses as `(!a).b`. When enabled, it parses as `!(a.b)`. Default behavior is preserved for backward compatibility with JMESPath standards.

Implementation adds `BP_LOW_NOT=8` constant and a `notBindingPower` instance field to the parser to dynamically select between tight (`BP_NOT=45`) and loose binding during expression parsing.

Comprehensive test coverage added with `test.each` for both affected cases and cases that remain unaffected by the option.